### PR TITLE
Add /blog powered by Voxx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+blog/node_modules/

--- a/_voxx/voxx-globals.css
+++ b/_voxx/voxx-globals.css
@@ -1,0 +1,61 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+:root {
+  --background: #ffffff;
+  --foreground: #09090b;
+  --muted: #f4f4f5;
+  --muted-foreground: #71717a;
+  --border: #e4e4e7;
+  --input: #e4e4e7;
+  --primary: #18181b;
+  --primary-foreground: #fafafa;
+  --accent: #f4f4f5;
+  --accent-foreground: #18181b;
+  --ring: #18181b;
+  --radius: 0.5rem;
+}
+
+.dark {
+  --background: #09090b;
+  --foreground: #fafafa;
+  --muted: #18181b;
+  --muted-foreground: #a1a1aa;
+  --border: #27272a;
+  --input: #27272a;
+  --primary: #fafafa;
+  --primary-foreground: #18181b;
+  --accent: #27272a;
+  --accent-foreground: #fafafa;
+  --ring: #d4d4d8;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not(.light) {
+    --background: #09090b;
+    --foreground: #fafafa;
+    --muted: #18181b;
+    --muted-foreground: #a1a1aa;
+    --border: #27272a;
+    --input: #27272a;
+    --primary: #fafafa;
+    --primary-foreground: #18181b;
+    --accent: #27272a;
+    --accent-foreground: #fafafa;
+    --ring: #d4d4d8;
+  }
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  background: var(--background);
+  color: var(--foreground);
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+}

--- a/_voxx/voxx.css
+++ b/_voxx/voxx.css
@@ -1,0 +1,1410 @@
+.voxx {
+  --voxx-bg: #ffffff;
+  --voxx-fg: #09090b;
+  --voxx-muted: #f4f4f5;
+  --voxx-muted-fg: #71717a;
+  --voxx-border: #e4e4e7;
+  --voxx-link: #2563eb;
+  --voxx-radius: 0.5rem;
+
+  color: var(--foreground, var(--voxx-fg));
+  font-family: var(
+    --voxx-font,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    "Segoe UI",
+    sans-serif
+  );
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not(.light) .voxx {
+    --voxx-bg: #09090b;
+    --voxx-fg: #fafafa;
+    --voxx-muted: #18181b;
+    --voxx-muted-fg: #a1a1aa;
+    --voxx-border: #27272a;
+    --voxx-link: #60a5fa;
+  }
+}
+
+.dark .voxx,
+.voxx.dark {
+  --voxx-bg: #09090b;
+  --voxx-fg: #fafafa;
+  --voxx-muted: #18181b;
+  --voxx-muted-fg: #a1a1aa;
+  --voxx-border: #27272a;
+  --voxx-link: #60a5fa;
+}
+
+.voxx-prose {
+  font-size: 1rem;
+  line-height: 1.75;
+  color: var(--foreground, var(--voxx-fg));
+}
+
+.voxx-prose > :first-child {
+  margin-top: 0;
+}
+
+.voxx-prose > :last-child {
+  margin-bottom: 0;
+}
+
+.voxx-prose :is(h1, h2, h3, h4) {
+  color: var(--foreground, var(--voxx-fg));
+  font-weight: 650;
+  line-height: 1.25;
+  letter-spacing: -0.015em;
+  scroll-margin-top: 5rem;
+}
+
+.voxx-prose h1 {
+  font-size: 2rem;
+  margin: 0 0 1.25rem;
+}
+
+.voxx-prose h2 {
+  font-size: 1.5rem;
+  margin: 2.5rem 0 1rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--border, var(--voxx-border));
+}
+
+.voxx-prose h3 {
+  font-size: 1.25rem;
+  margin: 2rem 0 0.75rem;
+}
+
+.voxx-prose h4 {
+  font-size: 1.05rem;
+  margin: 1.5rem 0 0.5rem;
+}
+
+.voxx-prose :is(h1, h2, h3, h4) > a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.voxx-prose p {
+  margin: 0 0 1.25rem;
+}
+
+.voxx-prose a {
+  color: var(--primary, var(--voxx-link));
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  text-decoration-thickness: 1px;
+}
+
+.voxx-prose a:hover {
+  text-decoration-thickness: 2px;
+}
+
+.voxx-prose :is(ul, ol) {
+  margin: 0 0 1.25rem;
+  padding-left: 1.5rem;
+}
+
+.voxx-prose li {
+  margin: 0.375rem 0;
+}
+
+.voxx-prose li::marker {
+  color: var(--muted-foreground, var(--voxx-muted-fg));
+}
+
+.voxx-prose blockquote {
+  margin: 1.5rem 0;
+  padding: 0.25rem 0 0.25rem 1.25rem;
+  border-left: 3px solid var(--border, var(--voxx-border));
+  color: var(--muted-foreground, var(--voxx-muted-fg));
+  font-style: italic;
+}
+
+.voxx-prose hr {
+  margin: 2.5rem 0;
+  border: 0;
+  border-top: 1px solid var(--border, var(--voxx-border));
+}
+
+.voxx-prose img {
+  max-width: 100%;
+  height: auto;
+  border-radius: var(--radius, var(--voxx-radius));
+  display: block;
+  margin: 1.5rem 0;
+}
+
+.voxx-prose :not(pre) > code {
+  font-family: var(--voxx-font-mono, ui-monospace, "SF Mono", Menlo, monospace);
+  font-size: 0.875em;
+  background: var(--muted, var(--voxx-muted));
+  border: 1px solid var(--border, var(--voxx-border));
+  border-radius: calc(var(--radius, var(--voxx-radius)) - 2px);
+  padding: 0.125rem 0.375rem;
+}
+
+.voxx-prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.9375rem;
+}
+
+.voxx-prose :is(th, td) {
+  border: 1px solid var(--border, var(--voxx-border));
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+}
+
+.voxx-prose th {
+  background: var(--muted, var(--voxx-muted));
+  font-weight: 600;
+}
+
+.voxx-prose pre {
+  margin: 1.5rem 0;
+  padding: 1rem 1.25rem;
+  max-width: 100%;
+  border-radius: var(--radius, var(--voxx-radius));
+  border: 1px solid var(--border, var(--voxx-border));
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-size: 0.875rem;
+  line-height: 1.6;
+}
+
+.voxx-prose pre code {
+  font-family: var(--voxx-font-mono, ui-monospace, "SF Mono", Menlo, monospace);
+  background: none;
+  border: 0;
+  padding: 0;
+}
+
+.voxx-prose .shiki,
+.voxx-prose .shiki span {
+  color: var(--shiki-light);
+}
+
+.voxx-prose .shiki {
+  background-color: var(--shiki-light-bg) !important;
+}
+
+@media (prefers-color-scheme: dark) {
+  .voxx-prose .shiki,
+  .voxx-prose .shiki span {
+    color: var(--shiki-dark);
+  }
+
+  .voxx-prose .shiki {
+    background-color: var(--shiki-dark-bg) !important;
+  }
+}
+
+.dark .voxx-prose .shiki,
+.dark .voxx-prose .shiki span {
+  color: var(--shiki-dark);
+}
+
+.dark .voxx-prose .shiki {
+  background-color: var(--shiki-dark-bg) !important;
+}
+
+.voxx-toc {
+  font-size: 0.8125rem;
+  line-height: 1.5;
+}
+
+.voxx-toc__title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0 0 0.5rem;
+  font-weight: 500;
+  color: var(--muted-foreground, var(--voxx-muted-fg));
+}
+
+.voxx-toc__title svg {
+  width: 1rem;
+  height: 1rem;
+  opacity: 0.7;
+}
+
+.voxx-toc__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.voxx-toc__item {
+  position: relative;
+}
+
+.voxx-toc__item::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--border, var(--voxx-border));
+}
+
+.voxx-toc__item[data-depth="3"]::before {
+  left: 0.625rem;
+}
+
+.voxx-toc__item[data-depth="4"]::before {
+  left: 1.25rem;
+}
+
+.voxx-toc__item a {
+  display: block;
+  padding: 0.375rem 0 0.375rem 0.875rem;
+  color: var(--muted-foreground, var(--voxx-muted-fg));
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+.voxx-toc__item[data-depth="3"] a {
+  padding-left: 1.625rem;
+}
+
+.voxx-toc__item[data-depth="4"] a {
+  padding-left: 2.25rem;
+}
+
+.voxx-toc__item a:hover {
+  color: var(--foreground, var(--voxx-fg));
+}
+
+.voxx-toc__body {
+  position: relative;
+}
+
+.voxx-toc__items {
+  display: flex;
+  flex-direction: column;
+}
+
+.voxx-toc__link {
+  position: relative;
+  display: block;
+  padding-top: 0.375rem;
+  padding-bottom: 0.375rem;
+  color: var(--muted-foreground, var(--voxx-muted-fg));
+  text-decoration: none;
+  overflow-wrap: anywhere;
+  transition: color 0.15s ease;
+}
+
+.voxx-toc__link:first-child {
+  padding-top: 0;
+}
+
+.voxx-toc__link:last-child {
+  padding-bottom: 0;
+}
+
+.voxx-toc__link:hover {
+  color: var(--foreground, var(--voxx-fg));
+}
+
+.voxx-toc__link[data-active="true"] {
+  color: var(--primary, var(--foreground, var(--voxx-fg)));
+}
+
+.voxx-toc__line {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--border, var(--voxx-border));
+}
+
+.voxx-toc__connector {
+  position: absolute;
+  top: -0.375rem;
+  inset-inline-start: 0;
+  width: 1rem;
+  height: 1rem;
+}
+
+.voxx-toc__connector line {
+  stroke: var(--border, var(--voxx-border));
+  stroke-width: 1;
+}
+
+.voxx-toc__mask {
+  position: absolute;
+  top: 0;
+  inset-inline-start: 0;
+  pointer-events: none;
+}
+
+.voxx-toc__thumb {
+  position: absolute;
+  width: 100%;
+  top: var(--voxx-toc-thumb-top, 0);
+  height: var(--voxx-toc-thumb-height, 0);
+  background: var(--primary, var(--foreground, var(--voxx-fg)));
+  transition:
+    top 0.15s ease,
+    height 0.15s ease;
+}
+
+.voxx-toc__thumb[data-hidden] {
+  opacity: 0;
+}
+
+.voxx-article {
+  max-width: 45rem;
+  margin: 0 auto;
+  min-width: 0;
+}
+
+.voxx-article__back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  margin-bottom: 1.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--muted-foreground, var(--voxx-muted-fg));
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+.voxx-article__back:hover {
+  color: var(--foreground, var(--voxx-fg));
+}
+
+.voxx-article__back svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.voxx-article__header {
+  margin-bottom: 2.5rem;
+}
+
+.voxx-article__header h1 {
+  font-size: clamp(1.875rem, 1.2rem + 2.5vw, 2.75rem);
+  font-weight: 700;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  margin: 0 0 0.75rem;
+  color: var(--foreground, var(--voxx-fg));
+}
+
+.voxx-article__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--muted-foreground, var(--voxx-muted-fg));
+}
+
+.voxx-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 3rem;
+  max-width: 70rem;
+  margin: 0 auto;
+  padding: 3.5rem 1.5rem 5rem;
+  min-width: 0;
+}
+
+@media (min-width: 1024px) {
+  .voxx-layout {
+    grid-template-columns: minmax(0, 1fr) 16rem;
+  }
+}
+
+.voxx-aside {
+  display: none;
+}
+
+@media (min-width: 1024px) {
+  .voxx-aside {
+    display: block;
+  }
+
+  .voxx-aside__inner {
+    position: sticky;
+    top: 2.5rem;
+  }
+}
+
+.voxx-index {
+  max-width: 45rem;
+  margin: 0 auto;
+  padding: 3.5rem 1.5rem 5rem;
+}
+
+.voxx-index__header {
+  margin-bottom: 2.5rem;
+}
+
+.voxx-index__header h1 {
+  font-size: 2.25rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0 0 0.5rem;
+  color: var(--foreground, var(--voxx-fg));
+}
+
+.voxx-index__desc {
+  margin: 0;
+  color: var(--muted-foreground, var(--voxx-muted-fg));
+  font-size: 1.0625rem;
+}
+
+.voxx-postlist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.voxx-postcard + .voxx-postcard {
+  border-top: 1px solid var(--border, var(--voxx-border));
+}
+
+.voxx-postcard__link {
+  display: block;
+  padding: 1.5rem 0;
+  text-decoration: none;
+  color: inherit;
+}
+
+.voxx-postcard__link:hover .voxx-postcard__title {
+  color: var(--primary, var(--voxx-link));
+}
+
+.voxx-postcard__title {
+  font-size: 1.3rem;
+  font-weight: 650;
+  letter-spacing: -0.01em;
+  margin: 0 0 0.35rem;
+  color: var(--foreground, var(--voxx-fg));
+  transition: color 0.15s ease;
+}
+
+.voxx-postcard__meta {
+  margin: 0 0 0.5rem;
+  font-size: 0.8125rem;
+  color: var(--muted-foreground, var(--voxx-muted-fg));
+}
+
+.voxx-postcard__excerpt {
+  margin: 0 0 0.75rem;
+  color: var(--muted-foreground, var(--voxx-muted-fg));
+  line-height: 1.6;
+}
+
+.voxx-tags {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0;
+  padding: 0;
+}
+
+.voxx-tag {
+  font-size: 0.75rem;
+  padding: 0.15rem 0.55rem;
+  border-radius: 9999px;
+  border: 1px solid var(--border, var(--voxx-border));
+  color: var(--muted-foreground, var(--voxx-muted-fg));
+  background: var(--muted, var(--voxx-muted));
+}
+
+.voxx-empty {
+  color: var(--muted-foreground, var(--voxx-muted-fg));
+}
+
+.voxx-header {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.625rem 1.5rem;
+  border-bottom: 1px solid var(--border, var(--voxx-border));
+  background: var(--background, var(--voxx-bg));
+}
+
+.voxx-header__title {
+  font-size: 1.0625rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--foreground, var(--voxx-fg));
+  text-decoration: none;
+}
+
+.voxx-header__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.voxx-docs {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  min-height: 100dvh;
+}
+
+@media (min-width: 768px) {
+  .voxx-docs {
+    grid-template-columns: 16rem minmax(0, 1fr);
+  }
+}
+
+.voxx-docs .voxx-layout {
+  max-width: none;
+  margin: 0;
+}
+
+.voxx-docs__nav-header {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+}
+
+.voxx-docs__title {
+  font-size: 1.0625rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--foreground, var(--voxx-fg));
+  text-decoration: none;
+}
+
+.voxx-docs__nav-footer {
+  display: flex;
+  align-items: center;
+  justify-content: end;
+}
+
+@media (min-width: 768px) {
+  .voxx-docs__nav {
+    display: block;
+    border-right: 1px solid var(--border, var(--voxx-border));
+    padding: 0;
+  }
+
+  .voxx-docs__nav-inner {
+    position: sticky;
+    top: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    height: 100dvh;
+    padding: 1.5rem 1.25rem;
+  }
+
+  .voxx-docs__nav .voxx-nav {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+  }
+
+  .voxx-docs__nav-header {
+    padding: 0 0.5rem;
+  }
+
+  .voxx-docs__nav-footer {
+    margin-top: auto;
+    padding: 1rem 0.5rem 0;
+    border-top: 1px solid var(--border, var(--voxx-border));
+  }
+}
+
+@media (max-width: 767.98px) {
+  .voxx-docs__nav {
+    position: sticky;
+    top: 0;
+    z-index: 40;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.625rem 1rem;
+    border-bottom: 1px solid var(--border, var(--voxx-border));
+    background: var(--background, var(--voxx-bg));
+  }
+
+  .voxx-docs__nav-inner {
+    display: contents;
+  }
+
+  .voxx-docs__nav-inner > .voxx-nav {
+    display: none;
+  }
+}
+
+.voxx-icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: 0;
+  background: none;
+  border: 0;
+  border-radius: calc(var(--radius, var(--voxx-radius)) - 2px);
+  color: var(--foreground, var(--voxx-fg));
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.voxx-icon-button:hover {
+  background: var(--muted, var(--voxx-muted));
+}
+
+.voxx-icon-button svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+@media (min-width: 768px) {
+  .voxx-menu-button {
+    display: none;
+  }
+}
+
+.voxx-theme-toggle .voxx-icon-sun {
+  display: none;
+}
+
+.dark .voxx-theme-toggle .voxx-icon-sun,
+:root.dark .voxx-theme-toggle .voxx-icon-sun {
+  display: block;
+}
+
+.dark .voxx-theme-toggle .voxx-icon-moon,
+:root.dark .voxx-theme-toggle .voxx-icon-moon {
+  display: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not(.light) .voxx-theme-toggle .voxx-icon-sun {
+    display: block;
+  }
+
+  :root:not(.light) .voxx-theme-toggle .voxx-icon-moon {
+    display: none;
+  }
+}
+
+.voxx-drawer {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+}
+
+.voxx-drawer__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgb(0 0 0 / 0.5);
+  animation: voxx-fade-in 0.15s ease;
+}
+
+.voxx-drawer__panel {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: min(20rem, 85vw);
+  display: flex;
+  flex-direction: column;
+  background: var(--background, var(--voxx-bg));
+  border-right: 1px solid var(--border, var(--voxx-border));
+  box-shadow: 0 8px 32px rgb(0 0 0 / 0.25);
+  animation: voxx-slide-in 0.2s ease;
+}
+
+.voxx-drawer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.875rem 1.25rem;
+  border-bottom: 1px solid var(--border, var(--voxx-border));
+}
+
+.voxx-drawer__body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 1rem 0.75rem;
+}
+
+@keyframes voxx-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes voxx-slide-in {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: none;
+  }
+}
+
+.voxx-docs__menu {
+  display: none;
+}
+
+@media (max-width: 767.98px) {
+  .voxx-docs__menu {
+    display: block;
+  }
+
+  .voxx-docs__menu > summary {
+    list-style: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.25rem;
+    height: 2.25rem;
+    border-radius: calc(var(--radius, var(--voxx-radius)) - 2px);
+    color: var(--foreground, var(--voxx-fg));
+    cursor: pointer;
+  }
+
+  .voxx-docs__menu > summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .voxx-docs__menu > summary:hover {
+    background: var(--muted, var(--voxx-muted));
+  }
+
+  .voxx-docs__menu > summary svg {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+
+  .voxx-docs__menu-panel {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    max-height: 70dvh;
+    overflow-y: auto;
+    padding: 1rem;
+    background: var(--background, var(--voxx-bg));
+    border-bottom: 1px solid var(--border, var(--voxx-border));
+    box-shadow: 0 8px 32px rgb(0 0 0 / 0.25);
+  }
+}
+
+.voxx-nav {
+  font-size: 0.875rem;
+}
+
+.voxx-nav__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.voxx-nav__list .voxx-nav__list {
+  margin: 0.125rem 0 0.375rem 0.625rem;
+  padding-left: 0.625rem;
+  border-left: 1px solid var(--border, var(--voxx-border));
+}
+
+.voxx-nav__section {
+  display: block;
+  margin: 1rem 0 0.25rem;
+  padding: 0 0.5rem;
+  font-weight: 600;
+  color: var(--foreground, var(--voxx-fg));
+}
+
+.voxx-nav__link {
+  display: block;
+  padding: 0.3rem 0.5rem;
+  border-radius: calc(var(--radius, var(--voxx-radius)) - 2px);
+  color: var(--muted-foreground, var(--voxx-muted-fg));
+  text-decoration: none;
+  transition:
+    color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.voxx-nav__link:hover {
+  color: var(--foreground, var(--voxx-fg));
+}
+
+.voxx-nav__link[data-active="true"] {
+  color: var(--foreground, var(--voxx-fg));
+  background: var(--muted, var(--voxx-muted));
+  font-weight: 500;
+}
+
+.voxx-releases {
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+.voxx-release__header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.voxx-release__version {
+  margin: 0;
+  font-size: 1.4rem;
+  font-weight: 650;
+  letter-spacing: -0.01em;
+}
+
+.voxx-release__version a {
+  color: var(--foreground, var(--voxx-fg));
+  text-decoration: none;
+}
+
+.voxx-release__version a:hover {
+  color: var(--primary, var(--voxx-link));
+}
+
+.voxx-release__header time {
+  font-size: 0.875rem;
+  color: var(--muted-foreground, var(--voxx-muted-fg));
+}
+
+.voxx-pager {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border, var(--voxx-border));
+}
+
+.voxx-pager__link {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  max-width: 48%;
+  text-decoration: none;
+}
+
+.voxx-pager__link--next {
+  text-align: right;
+  margin-left: auto;
+}
+
+.voxx-pager__label {
+  font-size: 0.75rem;
+  color: var(--muted-foreground, var(--voxx-muted-fg));
+}
+
+.voxx-pager__title {
+  font-weight: 600;
+  color: var(--foreground, var(--voxx-fg));
+}
+
+.voxx-pager__link:hover .voxx-pager__title {
+  color: var(--primary, var(--voxx-link));
+}
+@font-face {
+  font-family: 'iA Writer Quattro S';
+  src: url('/fonts/iAWriterQuattroS-Regular.woff2') format('woff2'),
+       url('/fonts/iAWriterQuattroS-Regular.woff') format('woff');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'iA Writer Quattro S';
+  src: url('/fonts/iAWriterQuattroS-Bold.woff2') format('woff2'),
+       url('/fonts/iAWriterQuattroS-Bold.woff') format('woff');
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'iA Writer Quattro S';
+  src: url('/fonts/iAWriterQuattroS-Italic.woff2') format('woff2'),
+       url('/fonts/iAWriterQuattroS-Italic.woff') format('woff');
+  font-weight: 400;
+  font-style: italic;
+  font-display: swap;
+}
+
+:root {
+  --aj-bg:           #ffffff;
+  --aj-ink:          #058c8c;
+  --aj-ink-dark:     #046363;
+  --aj-ink-darkest:  #023b3b;
+  --aj-ink-light:    #8ccaca;
+  --aj-ink-lighter:  #b2dbdb;
+  --aj-terra:        #a1665e;
+  --aj-grid-line:    1px solid #058c8c;
+  --aj-font:         'iA Writer Quattro S', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  --aj-font-mono:    'iA Writer Quattro S', 'Courier New', monospace;
+}
+
+.voxx {
+  --voxx-bg:       var(--aj-bg);
+  --voxx-fg:       var(--aj-ink-darkest);
+  --voxx-muted:    rgba(5, 140, 140, 0.06);
+  --voxx-muted-fg: var(--aj-ink);
+  --voxx-border:   var(--aj-ink);
+  --voxx-link:     var(--aj-terra);
+  --voxx-radius:   0px;
+  --voxx-font:     var(--aj-font);
+  --voxx-font-mono: var(--aj-font-mono);
+  color: var(--aj-ink-darkest);
+}
+
+body {
+  background: var(--aj-bg);
+  font-family: var(--aj-font);
+  -webkit-font-smoothing: antialiased;
+  cursor: default;
+}
+
+* { box-sizing: border-box; }
+
+a { cursor: crosshair; }
+button { cursor: crosshair; }
+
+.voxx-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  padding: 0;
+  background: var(--aj-bg);
+  border-bottom: var(--aj-grid-line);
+  border-radius: 0;
+}
+
+.voxx-header__title {
+  display: flex;
+  align-items: center;
+  padding: 0.75rem 1.5rem;
+  text-decoration: none;
+  border-right: var(--aj-grid-line);
+  opacity: 1;
+  transition: opacity 0.15s ease;
+}
+
+.voxx-header__title:hover {
+  opacity: 0.75;
+}
+
+.voxx-header__actions {
+  padding: 0 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.voxx-icon-button {
+  color: var(--aj-ink);
+  border-radius: 0;
+  width: 2rem;
+  height: 2rem;
+}
+
+.voxx-icon-button:hover {
+  background: rgba(5, 140, 140, 0.08);
+  color: var(--aj-ink-darkest);
+}
+
+.voxx-index {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 0 1.5rem 5rem;
+}
+
+.voxx-index__header {
+  padding: 3rem 0 2.5rem;
+  border-bottom: var(--aj-grid-line);
+  margin-bottom: 0;
+}
+
+.voxx-index__header h1 a {
+  color: var(--aj-ink-darkest);
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+.voxx-index__header h1 a:hover {
+  color: var(--aj-terra);
+}
+
+.voxx-index__header h1 {
+  font-family: var(--aj-font);
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 0.95;
+  color: var(--aj-ink-darkest);
+  margin: 0 0 0.75rem;
+}
+
+.voxx-index__desc {
+  font-size: 0.9rem;
+  font-family: var(--aj-font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--aj-ink);
+  margin: 0;
+  max-width: none;
+}
+
+
+.voxx-postlist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.voxx-postcard {
+  border-bottom: var(--aj-grid-line);
+}
+
+.voxx-postcard + .voxx-postcard {
+  border-top: none;
+}
+
+.voxx-postcard__link {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto auto auto;
+  column-gap: 2rem;
+  padding: 2rem 0;
+  text-decoration: none;
+  color: inherit;
+  align-items: start;
+}
+
+.voxx-postcard__title {
+  grid-column: 1;
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1.15;
+  color: var(--aj-ink-darkest);
+  margin: 0 0 0.5rem;
+  transition: color 0.15s ease;
+}
+
+.voxx-postcard__link:hover .voxx-postcard__title {
+  color: var(--aj-terra);
+}
+
+.voxx-postcard__excerpt {
+  grid-column: 1;
+  font-size: 0.9375rem;
+  line-height: 1.55;
+  color: var(--aj-ink-dark);
+  margin: 0 0 0.75rem;
+  max-width: 54ch;
+}
+
+.voxx-postcard__meta {
+  grid-column: 1 / -1;
+  grid-row: 1;
+  font-family: var(--aj-font-mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--aj-ink);
+  margin: 0 0 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+
+.voxx-tags {
+  grid-column: 1;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0;
+  padding: 0;
+}
+
+.voxx-tag {
+  font-family: var(--aj-font-mono);
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.2rem 0.6rem;
+  border: 1px solid var(--aj-ink-lighter);
+  color: var(--aj-ink);
+  background: rgba(5, 140, 140, 0.04);
+  border-radius: 0;
+}
+
+.voxx-layout {
+  padding: 3rem 1.5rem 5rem;
+  gap: 4rem;
+}
+
+.voxx-article__header {
+  margin-bottom: 3rem;
+  padding-bottom: 2rem;
+  border-bottom: var(--aj-grid-line);
+}
+
+.voxx-article__header h1 {
+  font-size: clamp(1.75rem, 3vw, 2.5rem);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 1.05;
+  color: var(--aj-ink-darkest);
+  margin: 0 0 1rem;
+}
+
+.voxx-article__meta {
+  font-family: var(--aj-font-mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--aj-ink);
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.voxx-prose {
+  font-family: var(--aj-font);
+  font-size: 1rem;
+  line-height: 1.65;
+  color: var(--aj-ink-darkest);
+}
+
+.voxx-prose p {
+  margin: 0 0 1.4rem;
+  color: var(--aj-ink-dark);
+}
+
+.voxx-prose :is(h2, h3, h4) {
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 1;
+  color: var(--aj-ink-darkest);
+  scroll-margin-top: 4rem;
+}
+
+.voxx-prose h2 {
+  font-size: 1.4rem;
+  margin: 3rem 0 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: var(--aj-grid-line);
+}
+
+.voxx-prose h3 {
+  font-size: 1.1rem;
+  margin: 2rem 0 0.75rem;
+}
+
+.voxx-prose h2 > a,
+.voxx-prose h3 > a,
+.voxx-prose h4 > a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.voxx-prose a {
+  color: var(--aj-terra);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1px;
+}
+
+.voxx-prose a:hover {
+  text-decoration-thickness: 2px;
+}
+
+.voxx-prose strong {
+  font-weight: 700;
+  color: var(--aj-ink-darkest);
+}
+
+.voxx-prose em {
+  font-style: italic;
+  color: var(--aj-ink-dark);
+}
+
+.voxx-prose :is(ul, ol) {
+  padding-left: 1.25rem;
+  margin: 0 0 1.4rem;
+}
+
+.voxx-prose li {
+  margin: 0.4rem 0;
+  color: var(--aj-ink-dark);
+}
+
+.voxx-prose li::marker {
+  color: var(--aj-ink-light);
+}
+
+.voxx-prose blockquote {
+  margin: 2rem 0;
+  padding: 0.25rem 0 0.25rem 1.25rem;
+  border-left: 3px solid var(--aj-terra);
+  color: var(--aj-ink);
+  font-style: italic;
+}
+
+.voxx-prose hr {
+  margin: 3rem 0;
+  border: 0;
+  border-top: var(--aj-grid-line);
+}
+
+.voxx-prose :not(pre) > code {
+  font-family: var(--aj-font-mono);
+  font-size: 0.875em;
+  background: rgba(5, 140, 140, 0.06);
+  border: 1px solid var(--aj-ink-lighter);
+  border-radius: 0;
+  padding: 0.1rem 0.35rem;
+  color: var(--aj-ink-dark);
+}
+
+.voxx-prose pre {
+  margin: 1.5rem 0;
+  padding: 1rem 1.25rem;
+  border: var(--aj-grid-line);
+  border-radius: 0;
+  background: rgba(5, 140, 140, 0.03) !important;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  overflow-x: auto;
+}
+
+.voxx-prose pre code {
+  font-family: var(--aj-font-mono);
+  background: none;
+  border: 0;
+  padding: 0;
+}
+
+.voxx-prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.9rem;
+}
+
+.voxx-prose :is(th, td) {
+  border: 1px solid var(--aj-ink-lighter);
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+}
+
+.voxx-prose th {
+  background: rgba(5, 140, 140, 0.06);
+  font-family: var(--aj-font-mono);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--aj-ink-dark);
+}
+
+.voxx-article__back {
+  color: var(--aj-ink);
+  font-family: var(--aj-font-mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.voxx-article__back:hover {
+  color: var(--aj-ink-darkest);
+}
+
+.voxx-aside {
+  display: none;
+}
+
+@media (min-width: 1024px) {
+  .voxx-aside {
+    display: block;
+  }
+
+  .voxx-aside__inner {
+    position: sticky;
+    top: 5rem;
+    padding-left: 2rem;
+  }
+}
+
+.voxx-toc__title {
+  font-family: var(--aj-font-mono);
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--aj-ink);
+  margin-bottom: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.voxx-toc__item::before {
+  background: var(--aj-ink-lighter);
+}
+
+.voxx-toc__item a {
+  font-size: 0.8125rem;
+  color: var(--aj-ink);
+  padding: 0.3rem 0 0.3rem 0.875rem;
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+.voxx-toc__item a:hover {
+  color: var(--aj-terra);
+}
+
+@media (max-width: 768px) {
+  .voxx-index { padding: 0 1rem 4rem; }
+  .voxx-index__header { padding: 2rem 0 1.5rem; }
+  .voxx-layout { padding: 2rem 1rem 4rem; gap: 2rem; }
+  .voxx-postcard__link { display: block; }
+  .voxx-header__title { font-size: 0.65rem; }
+}

--- a/ai-sprint/index.html
+++ b/ai-sprint/index.html
@@ -1,6 +1,7 @@
-<!DOCTYPE html SYSTEM "about:legacy-compat">
+<!DOCTYPE html>
 <html lang="en">
 <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
@@ -12,18 +13,18 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/favicon-32x32.png">
-<title>1-Month AI Development Sprint &#8212; Ajared Research Inc</title>
-<meta name="description" content="Ajared's 1-month AI Development Sprint takes your organization from readiness assessment to a working AI product &#8212; fast, focused, and built to last.">
+<title>1-Month AI Development Sprint — Ajared Research Inc</title>
+<meta name="description" content="Ajared's 1-month AI Development Sprint takes your organization from readiness assessment to a working AI product — fast, focused, and built to last.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://ajared.ca/ai-sprint/">
-<meta property="og:title" content="1-Month AI Development Sprint &#8212; Ajared Research Inc">
-<meta property="og:description" content="Ajared's 1-month AI Development Sprint takes your organization from readiness assessment to a working AI product &#8212; fast, focused, and built to last.">
+<meta property="og:title" content="1-Month AI Development Sprint — Ajared Research Inc">
+<meta property="og:description" content="Ajared's 1-month AI Development Sprint takes your organization from readiness assessment to a working AI product — fast, focused, and built to last.">
 <meta property="og:image" content="https://ajared.ca/social-card-bw.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="628">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="1-Month AI Development Sprint &#8212; Ajared Research Inc">
-<meta name="twitter:description" content="Ajared's 1-month AI Development Sprint takes your organization from readiness assessment to a working AI product &#8212; fast, focused, and built to last.">
+<meta name="twitter:title" content="1-Month AI Development Sprint — Ajared Research Inc">
+<meta name="twitter:description" content="Ajared's 1-month AI Development Sprint takes your organization from readiness assessment to a working AI product — fast, focused, and built to last.">
 <meta name="twitter:image" content="https://ajared.ca/social-card-bw.png">
 <style>
         /* iA Writer Quattro S Font */
@@ -257,7 +258,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             font-size: 1rem;
         }
 
-        /* Change 11: Nav hover &#8212; terra cotta */
+        /* Change 11: Nav hover — terra cotta */
         nav a:hover {
             text-decoration: underline;
             color: var(--color-terra);
@@ -313,7 +314,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             pointer-events: none;
         }
 
-        /* Change 10: Secondary ripple rings &#8212; subtle terra cotta tint */
+        /* Change 10: Secondary ripple rings — subtle terra cotta tint */
         .ripple-secondary {
             position: absolute;
             border-radius: 50%;
@@ -373,7 +374,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             margin-bottom: 0.5rem;
         }
 
-        /* Arrow &#8212; Change 3: terra cotta by default */
+        /* Arrow — Change 3: terra cotta by default */
         .arrow-icon {
             width: 40px;
             height: 1px;
@@ -406,7 +407,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             border-right-color: var(--color-bg);
         }
 
-        /* Stretched link &#8212; entire card is clickable */
+        /* Stretched link — entire card is clickable */
         .service-card > a {
             position: static;
         }
@@ -416,7 +417,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             inset: 0;
         }
 
-        /* Button &#8212; Change 1: terra cotta border + text, fills on hover */
+        /* Button — Change 1: terra cotta border + text, fills on hover */
         .btn {
             display: inline-block;
             margin-top: 2rem;
@@ -562,7 +563,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             color: var(--color-bg);
         }
 
-        /* Offer card tracks (card 03 &#8212; Get Started with AI) */
+        /* Offer card tracks (card 03 — Get Started with AI) */
         .track-list {
             margin-top: 1rem;
             display: flex;
@@ -759,7 +760,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         .hero-detail-content { position: relative; z-index: 1; }
         .hero-detail h1 { font-family: var(--font-primary); font-size: clamp(1.8rem, 3.5vw, 3.2rem); font-weight: 700; letter-spacing: -0.045em; line-height: 0.95; color: #fff; margin-bottom: 0; }
         
-        /* &#9472;&#9472; Essay + Marginalia layout (capability detail pages) &#9472;&#9472;&#9472; */
+        /* ── Essay + Marginalia layout (capability detail pages) ─── */
         .page-body { border-bottom: var(--grid-line); }
 
         .essay-section {
@@ -914,7 +915,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         .cta-btn { font-family: var(--font-mono); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--color-terra); border: 2px solid var(--color-terra); padding: 0.9rem 1.8rem; transition: background 0.2s, color 0.2s; white-space: nowrap; background: transparent; }
         .cta-btn:hover { background: var(--color-terra); color: #fff; }
 
-        /* &#9472;&#9472; Deliverable List &#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472; */
+        /* ── Deliverable List ─────────────────────────────────── */
         .deliverable-list { border-top: var(--grid-line); }
         .deliverable-row {
             display: grid;
@@ -1044,9 +1045,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <p><a href="/case-studies/">Case Studies</a></p>
 <p><a href="/capabilities/">Capabilities</a></p>
 <p><a href="/contact/" style="text-decoration:underline; font-weight:600; color: var(--color-terra);">Contact</a></p>
-<p><a href="https://www.ajared.ng">Read</a></p></nav><div style="font-size: 2rem; line-height: 1; color: var(--color-terra);">&#8599;</div>
+<p><a href="/blog/">Blog</a></p>
+<p><a href="https://www.ajared.ng">Read</a></p></nav><div style="font-size: 2rem; line-height: 1; color: var(--color-terra);">↗</div>
 </div></header><style>
-      /* &#9472;&#9472; Sprint Assessment &#9472;&#9472; */
+      /* ── Sprint Assessment ── */
       .sprint-hero {
         padding: 3rem 2rem;
         border-bottom: var(--grid-line);
@@ -1355,7 +1357,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </div>
 <div id="sprint-questions"></div>
 <div class="sprint-submit-row">
-<button class="sprint-btn" id="sprint-submit" disabled>See Readiness Report &#8599;</button><span class="sprint-submit-hint" id="sprint-submit-hint">Answer all questions to continue</span>
+<button class="sprint-btn" id="sprint-submit" disabled>See Readiness Report ↗</button><span class="sprint-submit-hint" id="sprint-submit-hint">Answer all questions to continue</span>
 </div>
 </div>
 <div id="sprint-lead" style="display:none"><div class="sprint-lead-inner">
@@ -1364,14 +1366,14 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <p>Enter your details to unlock your sprint readiness profile and personalized preparation plan.</p>
 </div>
 <div class="sprint-lead-right"><form id="sprint-lead-form" action="https://formspree.io/f/mwvrkwll" method="POST">
-<input type="hidden" name="_subject" value="1 Month AI Development Sprint &#8212; Assessment"><input type="hidden" name="assessment_level" id="sprint-hidden-level"><input type="hidden" name="assessment_score" id="sprint-hidden-score"><input type="hidden" name="assessment_answers" id="sprint-hidden-answers"><div class="instrument-field">
+<input type="hidden" name="_subject" value="1 Month AI Development Sprint — Assessment"><input type="hidden" name="assessment_level" id="sprint-hidden-level"><input type="hidden" name="assessment_score" id="sprint-hidden-score"><input type="hidden" name="assessment_answers" id="sprint-hidden-answers"><div class="instrument-field">
 <span class="label">Name</span><input type="text" name="name" id="sprint-lead-name" class="instrument-input" placeholder="Your name">
 </div>
 <div class="instrument-field" style="margin-top: 1rem;">
 <span class="label">Email</span><input type="email" name="email" id="sprint-lead-email" class="instrument-input" placeholder="you@example.com" required="required">
 </div>
 <div id="sprint-lead-error" style="display:none; color:var(--color-terra); font-family:var(--font-mono); font-size:0.8rem; text-transform:uppercase; letter-spacing:0.06em; margin-top:1rem;"></div>
-<button type="submit" class="sprint-btn" style="margin-top:1.5rem; width:100%;">Show My Report &#8599;</button>
+<button type="submit" class="sprint-btn" style="margin-top:1.5rem; width:100%;">Show My Report ↗</button>
 </form></div>
 </div></div>
 <div id="sprint-results" style="display:none"><div class="sprint-results-inner">
@@ -1389,16 +1391,16 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <div>
 <span class="label">Ready to apply?</span><p style="margin-top:0.5rem;">Book a 20-minute discovery call to confirm your spot and align on sprint goals.</p>
 </div>
-<a href="https://cal.com/ajared" target="_blank" rel="noopener noreferrer" class="sprint-btn" style="white-space:nowrap; display:inline-block;">Book a Discovery Call &#8599;</a>
+<a href="https://cal.com/ajared" target="_blank" rel="noopener noreferrer" class="sprint-btn" style="white-space:nowrap; display:inline-block;">Book a Discovery Call ↗</a>
 </div>
-<div style="text-align:center;"><button class="sprint-retake" id="sprint-retake">&#8635; Retake Assessment</button></div>
+<div style="text-align:center;"><button class="sprint-retake" id="sprint-retake">↻ Retake Assessment</button></div>
 </div></div>
 <div class="footer">
 <div>
 <span class="label" style="color: var(--color-terra);">Inquiries</span><h2><a href="mailto:innovation@ajared.ca">innovation@<span style="color: #a1665e;">aja</span>red.ca</a></h2>
 </div>
 <div style="text-align:right; display:flex; flex-direction:column; justify-content:center; align-items:flex-end; gap:0.5rem;">
-<p>&#169; 2026 Ajared Research Inc.</p>
+<p>© 2026 Ajared Research Inc.</p>
 <span class="label">R<span style="color:#a1665e">e</span>s<span style="color:#a1665e">ea</span>rch,
                 <span style="color:#a1665e">e</span>d<span style="color:#a1665e">u</span>c<span style="color:#a1665e">a</span>t<span style="color:#a1665e">e</span>, d<span style="color:#a1665e">e</span>s<span style="color:#a1665e">i</span>gn.</span>
 </div>

--- a/blog/ajared-theme.css
+++ b/blog/ajared-theme.css
@@ -1,0 +1,475 @@
+@font-face {
+  font-family: 'iA Writer Quattro S';
+  src: url('/fonts/iAWriterQuattroS-Regular.woff2') format('woff2'),
+       url('/fonts/iAWriterQuattroS-Regular.woff') format('woff');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'iA Writer Quattro S';
+  src: url('/fonts/iAWriterQuattroS-Bold.woff2') format('woff2'),
+       url('/fonts/iAWriterQuattroS-Bold.woff') format('woff');
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'iA Writer Quattro S';
+  src: url('/fonts/iAWriterQuattroS-Italic.woff2') format('woff2'),
+       url('/fonts/iAWriterQuattroS-Italic.woff') format('woff');
+  font-weight: 400;
+  font-style: italic;
+  font-display: swap;
+}
+
+:root {
+  --aj-bg:           #ffffff;
+  --aj-ink:          #058c8c;
+  --aj-ink-dark:     #046363;
+  --aj-ink-darkest:  #023b3b;
+  --aj-ink-light:    #8ccaca;
+  --aj-ink-lighter:  #b2dbdb;
+  --aj-terra:        #a1665e;
+  --aj-grid-line:    1px solid #058c8c;
+  --aj-font:         'iA Writer Quattro S', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  --aj-font-mono:    'iA Writer Quattro S', 'Courier New', monospace;
+}
+
+.voxx {
+  --voxx-bg:       var(--aj-bg);
+  --voxx-fg:       var(--aj-ink-darkest);
+  --voxx-muted:    rgba(5, 140, 140, 0.06);
+  --voxx-muted-fg: var(--aj-ink);
+  --voxx-border:   var(--aj-ink);
+  --voxx-link:     var(--aj-terra);
+  --voxx-radius:   0px;
+  --voxx-font:     var(--aj-font);
+  --voxx-font-mono: var(--aj-font-mono);
+  color: var(--aj-ink-darkest);
+}
+
+body {
+  background: var(--aj-bg);
+  font-family: var(--aj-font);
+  -webkit-font-smoothing: antialiased;
+  cursor: default;
+}
+
+* { box-sizing: border-box; }
+
+a { cursor: crosshair; }
+button { cursor: crosshair; }
+
+.voxx-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  padding: 0;
+  background: var(--aj-bg);
+  border-bottom: var(--aj-grid-line);
+  border-radius: 0;
+}
+
+.voxx-header__title {
+  display: flex;
+  align-items: center;
+  padding: 0.75rem 1.5rem;
+  text-decoration: none;
+  border-right: var(--aj-grid-line);
+  opacity: 1;
+  transition: opacity 0.15s ease;
+}
+
+.voxx-header__title:hover {
+  opacity: 0.75;
+}
+
+.voxx-header__actions {
+  padding: 0 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.voxx-icon-button {
+  color: var(--aj-ink);
+  border-radius: 0;
+  width: 2rem;
+  height: 2rem;
+}
+
+.voxx-icon-button:hover {
+  background: rgba(5, 140, 140, 0.08);
+  color: var(--aj-ink-darkest);
+}
+
+.voxx-index {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 0 1.5rem 5rem;
+}
+
+.voxx-index__header {
+  padding: 3rem 0 2.5rem;
+  border-bottom: var(--aj-grid-line);
+  margin-bottom: 0;
+}
+
+.voxx-index__header h1 a {
+  color: var(--aj-ink-darkest);
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+.voxx-index__header h1 a:hover {
+  color: var(--aj-terra);
+}
+
+.voxx-index__header h1 {
+  font-family: var(--aj-font);
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 0.95;
+  color: var(--aj-ink-darkest);
+  margin: 0 0 0.75rem;
+}
+
+.voxx-index__desc {
+  font-size: 0.9rem;
+  font-family: var(--aj-font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--aj-ink);
+  margin: 0;
+  max-width: none;
+}
+
+
+.voxx-postlist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.voxx-postcard {
+  border-bottom: var(--aj-grid-line);
+}
+
+.voxx-postcard + .voxx-postcard {
+  border-top: none;
+}
+
+.voxx-postcard__link {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto auto auto;
+  column-gap: 2rem;
+  padding: 2rem 0;
+  text-decoration: none;
+  color: inherit;
+  align-items: start;
+}
+
+.voxx-postcard__title {
+  grid-column: 1;
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1.15;
+  color: var(--aj-ink-darkest);
+  margin: 0 0 0.5rem;
+  transition: color 0.15s ease;
+}
+
+.voxx-postcard__link:hover .voxx-postcard__title {
+  color: var(--aj-terra);
+}
+
+.voxx-postcard__excerpt {
+  grid-column: 1;
+  font-size: 0.9375rem;
+  line-height: 1.55;
+  color: var(--aj-ink-dark);
+  margin: 0 0 0.75rem;
+  max-width: 54ch;
+}
+
+.voxx-postcard__meta {
+  grid-column: 1 / -1;
+  grid-row: 1;
+  font-family: var(--aj-font-mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--aj-ink);
+  margin: 0 0 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+
+.voxx-tags {
+  grid-column: 1;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0;
+  padding: 0;
+}
+
+.voxx-tag {
+  font-family: var(--aj-font-mono);
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.2rem 0.6rem;
+  border: 1px solid var(--aj-ink-lighter);
+  color: var(--aj-ink);
+  background: rgba(5, 140, 140, 0.04);
+  border-radius: 0;
+}
+
+.voxx-layout {
+  padding: 3rem 1.5rem 5rem;
+  gap: 4rem;
+}
+
+.voxx-article__header {
+  margin-bottom: 3rem;
+  padding-bottom: 2rem;
+  border-bottom: var(--aj-grid-line);
+}
+
+.voxx-article__header h1 {
+  font-size: clamp(1.75rem, 3vw, 2.5rem);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 1.05;
+  color: var(--aj-ink-darkest);
+  margin: 0 0 1rem;
+}
+
+.voxx-article__meta {
+  font-family: var(--aj-font-mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--aj-ink);
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.voxx-prose {
+  font-family: var(--aj-font);
+  font-size: 1rem;
+  line-height: 1.65;
+  color: var(--aj-ink-darkest);
+}
+
+.voxx-prose p {
+  margin: 0 0 1.4rem;
+  color: var(--aj-ink-dark);
+}
+
+.voxx-prose :is(h2, h3, h4) {
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 1;
+  color: var(--aj-ink-darkest);
+  scroll-margin-top: 4rem;
+}
+
+.voxx-prose h2 {
+  font-size: 1.4rem;
+  margin: 3rem 0 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: var(--aj-grid-line);
+}
+
+.voxx-prose h3 {
+  font-size: 1.1rem;
+  margin: 2rem 0 0.75rem;
+}
+
+.voxx-prose h2 > a,
+.voxx-prose h3 > a,
+.voxx-prose h4 > a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.voxx-prose a {
+  color: var(--aj-terra);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1px;
+}
+
+.voxx-prose a:hover {
+  text-decoration-thickness: 2px;
+}
+
+.voxx-prose strong {
+  font-weight: 700;
+  color: var(--aj-ink-darkest);
+}
+
+.voxx-prose em {
+  font-style: italic;
+  color: var(--aj-ink-dark);
+}
+
+.voxx-prose :is(ul, ol) {
+  padding-left: 1.25rem;
+  margin: 0 0 1.4rem;
+}
+
+.voxx-prose li {
+  margin: 0.4rem 0;
+  color: var(--aj-ink-dark);
+}
+
+.voxx-prose li::marker {
+  color: var(--aj-ink-light);
+}
+
+.voxx-prose blockquote {
+  margin: 2rem 0;
+  padding: 0.25rem 0 0.25rem 1.25rem;
+  border-left: 3px solid var(--aj-terra);
+  color: var(--aj-ink);
+  font-style: italic;
+}
+
+.voxx-prose hr {
+  margin: 3rem 0;
+  border: 0;
+  border-top: var(--aj-grid-line);
+}
+
+.voxx-prose :not(pre) > code {
+  font-family: var(--aj-font-mono);
+  font-size: 0.875em;
+  background: rgba(5, 140, 140, 0.06);
+  border: 1px solid var(--aj-ink-lighter);
+  border-radius: 0;
+  padding: 0.1rem 0.35rem;
+  color: var(--aj-ink-dark);
+}
+
+.voxx-prose pre {
+  margin: 1.5rem 0;
+  padding: 1rem 1.25rem;
+  border: var(--aj-grid-line);
+  border-radius: 0;
+  background: rgba(5, 140, 140, 0.03) !important;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  overflow-x: auto;
+}
+
+.voxx-prose pre code {
+  font-family: var(--aj-font-mono);
+  background: none;
+  border: 0;
+  padding: 0;
+}
+
+.voxx-prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.9rem;
+}
+
+.voxx-prose :is(th, td) {
+  border: 1px solid var(--aj-ink-lighter);
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+}
+
+.voxx-prose th {
+  background: rgba(5, 140, 140, 0.06);
+  font-family: var(--aj-font-mono);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--aj-ink-dark);
+}
+
+.voxx-article__back {
+  color: var(--aj-ink);
+  font-family: var(--aj-font-mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.voxx-article__back:hover {
+  color: var(--aj-ink-darkest);
+}
+
+.voxx-aside {
+  display: none;
+}
+
+@media (min-width: 1024px) {
+  .voxx-aside {
+    display: block;
+  }
+
+  .voxx-aside__inner {
+    position: sticky;
+    top: 5rem;
+    padding-left: 2rem;
+  }
+}
+
+.voxx-toc__title {
+  font-family: var(--aj-font-mono);
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--aj-ink);
+  margin-bottom: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.voxx-toc__item::before {
+  background: var(--aj-ink-lighter);
+}
+
+.voxx-toc__item a {
+  font-size: 0.8125rem;
+  color: var(--aj-ink);
+  padding: 0.3rem 0 0.3rem 0.875rem;
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+.voxx-toc__item a:hover {
+  color: var(--aj-terra);
+}
+
+@media (max-width: 768px) {
+  .voxx-index { padding: 0 1rem 4rem; }
+  .voxx-index__header { padding: 2rem 0 1.5rem; }
+  .voxx-layout { padding: 2rem 1rem 4rem; gap: 2rem; }
+  .voxx-postcard__link { display: block; }
+  .voxx-header__title { font-size: 0.65rem; }
+}

--- a/blog/content/hello-world.md
+++ b/blog/content/hello-world.md
@@ -1,0 +1,42 @@
+---
+title: Hello, world
+description: Your very first Voxx post — edit or delete me.
+date: 2026-06-13
+tags: [getting-started]
+category: General
+---
+
+Welcome to your new blog. This file is just markdown with a little YAML
+frontmatter on top, so you can write a post in any editor and commit it like
+code.
+
+## Why JSON was the wrong surface
+
+Configuration files are great for machines and miserable for writing. Prose
+wants to be prose — headings, paragraphs, the occasional list:
+
+- No database to run
+- No admin UI to log into
+- Just files you can grep, diff, and version
+
+## One line, that's all
+
+Voxx reads this file, parses the frontmatter, renders the markdown, and hands
+your app clean data. Code blocks are highlighted automatically:
+
+```ts
+import { getPosts } from "@prudentbird/voxx-core";
+
+const posts = await getPosts();
+```
+
+## A format that plays well with AI
+
+Because every post is self-describing — explicit metadata, natural-language
+body — both humans and agents can read and write them. Voxx can even emit an
+`llms.txt` so models can discover your writing.
+
+## Final thoughts
+
+Edit `voxx.json` to configure the blog, drop more `.md` files next to this one,
+and you're publishing. That's the whole idea.

--- a/blog/decksense-engineering/index.html
+++ b/blog/decksense-engineering/index.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Building DeckSense: Stack, Architecture, and Hard-Won Lessons — Ajared Research</title>
+    <link rel="stylesheet" href="../../_voxx/voxx-globals.css">
+    <link rel="stylesheet" href="../../_voxx/voxx.css">
+    <meta name="description" content="An honest engineering post-mortem on DeckSense — the stack we chose, the architecture decisions that held up, the ones that didn&apos;t, and what we&apos;d do differently.">
+    <link rel="canonical" href="https://ajared.ca/blog/decksense-engineering">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="Building DeckSense: Stack, Architecture, and Hard-Won Lessons">
+    <meta property="og:description" content="An honest engineering post-mortem on DeckSense — the stack we chose, the architecture decisions that held up, the ones that didn&apos;t, and what we&apos;d do differently.">
+    <meta property="og:url" content="https://ajared.ca/blog/decksense-engineering">
+    <meta property="og:site_name" content="Ajared Research">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Building DeckSense: Stack, Architecture, and Hard-Won Lessons">
+    <meta name="twitter:description" content="An honest engineering post-mortem on DeckSense — the stack we chose, the architecture decisions that held up, the ones that didn&apos;t, and what we&apos;d do differently.">
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Building DeckSense: Stack, Architecture, and Hard-Won Lessons","description":"An honest engineering post-mortem on DeckSense — the stack we chose, the architecture decisions that held up, the ones that didn't, and what we'd do differently.","datePublished":"2026-06-13T00:00:00.000Z","dateModified":"2026-06-13T00:00:00.000Z","author":{"@type":"Person","name":"PrudentBird","url":"https://ajared.ca"},"keywords":"engineering, ai, product","mainEntityOfPage":{"@type":"WebPage","@id":"https://ajared.ca/blog/decksense-engineering"},"publisher":{"@type":"Organization","name":"Ajared Research"}}</script>
+  </head>
+  <body>
+    <header class="voxx voxx-header">
+      <a class="voxx-header__title" href="../../"><img src="/logo.png" alt="Ajared Research" style="height:28px;width:auto;display:block;"/></a>
+      <div class="voxx-header__actions"><a class="voxx-icon-button" href="../../blog/rss.xml" aria-label="RSS feed"><svg viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M4 11a9 9 0 0 1 9 9M4 4a16 16 0 0 1 16 16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><circle cx="5" cy="19" r="1" fill="currentColor"/></svg></a></div>
+    </header>
+    <main class="voxx voxx-layout">
+      <article class="voxx-article">
+        <a class="voxx-article__back" href="../../blog"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M10 12 6 8l4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>All posts</a>
+        <header class="voxx-article__header">
+          <h1>Building DeckSense: Stack, Architecture, and Hard-Won Lessons</h1>
+          <p class="voxx-article__meta"><time datetime="2026-06-13T00:00:00.000Z">June 13, 2026</time> · 1 min read</p>
+        </header>
+        <div class="voxx-prose"><p><strong>wip</strong></p>
+<img alt="image" src="https://prudentbird.com/opengraph-image.png"></div>
+      </article>
+
+    </main>
+  </body>
+</html>

--- a/blog/hello-world/index.html
+++ b/blog/hello-world/index.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Hello, world — Ajared Research</title>
+    <link rel="stylesheet" href="../../_voxx/voxx-globals.css">
+    <link rel="stylesheet" href="../../_voxx/voxx.css">
+    <meta name="description" content="Your very first Voxx post — edit or delete me.">
+    <link rel="canonical" href="https://ajared.ca/blog/hello-world">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="Hello, world">
+    <meta property="og:description" content="Your very first Voxx post — edit or delete me.">
+    <meta property="og:url" content="https://ajared.ca/blog/hello-world">
+    <meta property="og:site_name" content="Ajared Research">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Hello, world">
+    <meta name="twitter:description" content="Your very first Voxx post — edit or delete me.">
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Hello, world","description":"Your very first Voxx post — edit or delete me.","datePublished":"2026-06-13T00:00:00.000Z","dateModified":"2026-06-13T00:00:00.000Z","author":{"@type":"Person","name":"Ajared Research Inc.","url":"https://ajared.ca"},"keywords":"getting-started","mainEntityOfPage":{"@type":"WebPage","@id":"https://ajared.ca/blog/hello-world"},"publisher":{"@type":"Organization","name":"Ajared Research"}}</script>
+  </head>
+  <body>
+    <header class="voxx voxx-header">
+      <a class="voxx-header__title" href="../../"><img src="/logo.png" alt="Ajared Research" style="height:28px;width:auto;display:block;"/></a>
+      <div class="voxx-header__actions"><a class="voxx-icon-button" href="../../blog/rss.xml" aria-label="RSS feed"><svg viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M4 11a9 9 0 0 1 9 9M4 4a16 16 0 0 1 16 16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><circle cx="5" cy="19" r="1" fill="currentColor"/></svg></a></div>
+    </header>
+    <main class="voxx voxx-layout">
+      <article class="voxx-article">
+        <a class="voxx-article__back" href="../../blog"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M10 12 6 8l4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>All posts</a>
+        <header class="voxx-article__header">
+          <h1>Hello, world</h1>
+          <p class="voxx-article__meta"><time datetime="2026-06-13T00:00:00.000Z">June 13, 2026</time> · 1 min read</p>
+        </header>
+        <div class="voxx-prose"><p>Welcome to your new blog. This file is just markdown with a little YAML
+frontmatter on top, so you can write a post in any editor and commit it like
+code.</p>
+<h2 id="why-json-was-the-wrong-surface"><a href="#why-json-was-the-wrong-surface">Why JSON was the wrong surface</a></h2>
+<p>Configuration files are great for machines and miserable for writing. Prose
+wants to be prose — headings, paragraphs, the occasional list:</p>
+<ul>
+<li>No database to run</li>
+<li>No admin UI to log into</li>
+<li>Just files you can grep, diff, and version</li>
+</ul>
+<h2 id="one-line-thats-all"><a href="#one-line-thats-all">One line, that's all</a></h2>
+<p>Voxx reads this file, parses the frontmatter, renders the markdown, and hands
+your app clean data. Code blocks are highlighted automatically:</p>
+<pre class="shiki shiki-themes github-light github-dark" style="--shiki-light:#24292e;--shiki-dark:#e1e4e8;--shiki-light-bg:#fff;--shiki-dark-bg:#24292e" tabindex="0"><code><span class="line"><span style="--shiki-light:#D73A49;--shiki-dark:#F97583">import</span><span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8"> { getPosts } </span><span style="--shiki-light:#D73A49;--shiki-dark:#F97583">from</span><span style="--shiki-light:#032F62;--shiki-dark:#9ECBFF"> "@prudentbird/voxx-core"</span><span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8">;</span></span>
+<span class="line"></span>
+<span class="line"><span style="--shiki-light:#D73A49;--shiki-dark:#F97583">const</span><span style="--shiki-light:#005CC5;--shiki-dark:#79B8FF"> posts</span><span style="--shiki-light:#D73A49;--shiki-dark:#F97583"> =</span><span style="--shiki-light:#D73A49;--shiki-dark:#F97583"> await</span><span style="--shiki-light:#6F42C1;--shiki-dark:#B392F0"> getPosts</span><span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8">();</span></span></code></pre>
+<h2 id="a-format-that-plays-well-with-ai"><a href="#a-format-that-plays-well-with-ai">A format that plays well with AI</a></h2>
+<p>Because every post is self-describing — explicit metadata, natural-language
+body — both humans and agents can read and write them. Voxx can even emit an
+<code>llms.txt</code> so models can discover your writing.</p>
+<h2 id="final-thoughts"><a href="#final-thoughts">Final thoughts</a></h2>
+<p>Edit <code>voxx.json</code> to configure the blog, drop more <code>.md</code> files next to this one,
+and you're publishing. That's the whole idea.</p></div>
+      </article>
+      <aside class="voxx-aside"><div class="voxx-aside__inner">
+        <nav class="voxx-toc" aria-label="On this page">
+          <p class="voxx-toc__title"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M2.5 4h7M2.5 8h11M2.5 12h7" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>On this page</p>
+          <ul class="voxx-toc__list">
+          <li class="voxx-toc__item" data-depth="2"><a href="#why-json-was-the-wrong-surface">Why JSON was the wrong surface</a></li>
+          <li class="voxx-toc__item" data-depth="2"><a href="#one-line-thats-all">One line, that&apos;s all</a></li>
+          <li class="voxx-toc__item" data-depth="2"><a href="#a-format-that-plays-well-with-ai">A format that plays well with AI</a></li>
+          <li class="voxx-toc__item" data-depth="2"><a href="#final-thoughts">Final thoughts</a></li>
+          </ul>
+        </nav>
+      </div></aside>
+    </main>
+  </body>
+</html>

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Ajared Research</title>
+    <link rel="stylesheet" href="../_voxx/voxx-globals.css">
+    <link rel="stylesheet" href="../_voxx/voxx.css">
+    <meta name="description" content="Engineering and strategy notes from the Ajared Research team.">
+  </head>
+  <body>
+    <header class="voxx voxx-header">
+      <a class="voxx-header__title" href="../"><img src="/logo.png" alt="Ajared Research" style="height:28px;width:auto;display:block;"/></a>
+      <div class="voxx-header__actions"><a class="voxx-icon-button" href="../blog/rss.xml" aria-label="RSS feed"><svg viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M4 11a9 9 0 0 1 9 9M4 4a16 16 0 0 1 16 16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><circle cx="5" cy="19" r="1" fill="currentColor"/></svg></a></div>
+    </header>
+    <main class="voxx voxx-index">
+      <header class="voxx-index__header">
+        <h1><a href="/" style="text-decoration:none;">Ajared Research</a></h1>
+        <p class="voxx-index__desc">Engineering and strategy notes from the Ajared Research team.</p>
+      </header>
+      <ul class="voxx-postlist">
+      <li class="voxx-postcard"><a class="voxx-postcard__link" href="../blog/hello-world">
+        <h2 class="voxx-postcard__title">Hello, world</h2>
+        <p class="voxx-postcard__meta"><time datetime="2026-06-13T00:00:00.000Z">June 13, 2026</time> · 1 min read</p>
+        <p class="voxx-postcard__excerpt">Welcome to your new blog. This file is just markdown with a little YAML frontmatter on top, so you can write a post in any editor and commit it like code. Configuration files are…</p>
+        <ul class="voxx-tags"><li class="voxx-tag">getting-started</li></ul>
+      </a></li>
+    </ul>
+    </main>
+  </body>
+</html>

--- a/blog/package-lock.json
+++ b/blog/package-lock.json
@@ -1,0 +1,2776 @@
+{
+  "name": "@ajared/blog",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@ajared/blog",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@prudentbird/voxx": "^1.1.0",
+        "@prudentbird/voxx-core": "^1.1.0"
+      }
+    },
+    "node_modules/@effect/cluster": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@effect/cluster/-/cluster-0.59.0.tgz",
+      "integrity": "sha512-rxtJ0zlcdDDtn9wau0z/PFfwPP2FsYPB2/tSK4tT8DkTYQmACJ5AwRwZm3Ea83iL/gv3df63lRe94oMiS8bFfg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "kubernetes-types": "^1.30.0"
+      },
+      "peerDependencies": {
+        "@effect/platform": "^0.96.1",
+        "@effect/rpc": "^0.75.1",
+        "@effect/sql": "^0.51.1",
+        "@effect/workflow": "^0.18.2",
+        "effect": "^3.21.2"
+      }
+    },
+    "node_modules/@effect/experimental": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@effect/experimental/-/experimental-0.60.0.tgz",
+      "integrity": "sha512-i5zIg7Xup2KgHyqHlYtkgqSE1bNzCL0GbbTQxrpIzKF0q/ebknOk/ox8B/gIq2vImjoEE81h/oxU+6i1NH210g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "uuid": "^11.0.3"
+      },
+      "peerDependencies": {
+        "@effect/platform": "^0.96.0",
+        "effect": "^3.21.0",
+        "ioredis": "^5",
+        "lmdb": "^3"
+      },
+      "peerDependenciesMeta": {
+        "ioredis": {
+          "optional": true
+        },
+        "lmdb": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@effect/platform": {
+      "version": "0.96.1",
+      "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.96.1.tgz",
+      "integrity": "sha512-cjB1QZZYEP8JXCFNGvBLVi0T6YUBQTmOVEUA3SDbiQ6RUO+p6CE3eyD2vMWmrz5nE8yY5QSAuOV9v0boEcUv+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-my-way-ts": "^0.1.6",
+        "msgpackr": "^1.11.10",
+        "multipasta": "^0.2.7"
+      },
+      "peerDependencies": {
+        "effect": "^3.21.2"
+      }
+    },
+    "node_modules/@effect/platform-node": {
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/@effect/platform-node/-/platform-node-0.107.0.tgz",
+      "integrity": "sha512-VWUD9SCcnsrXYqED2jIwDHHDGb3QePNsHlX7HfqQGD2/AgnfX9jNnecaFrJj7Rf2gK5VbRE+i/2oNFoC/DkhcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@effect/platform-node-shared": "^0.60.0",
+        "mime": "^3.0.0",
+        "undici": "^7.10.0",
+        "ws": "^8.18.2"
+      },
+      "peerDependencies": {
+        "@effect/cluster": "^0.59.0",
+        "@effect/platform": "^0.96.1",
+        "@effect/rpc": "^0.75.1",
+        "@effect/sql": "^0.51.1",
+        "effect": "^3.21.2"
+      }
+    },
+    "node_modules/@effect/platform-node-shared": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@effect/platform-node-shared/-/platform-node-shared-0.60.0.tgz",
+      "integrity": "sha512-obT8Mau/guSYjehF9pg09FHM/ERXAAVBl/FXRXEyvTc7ZiDGTYnPBihytGNccsfNsgqBdvCE24sflwK6j5nFXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/watcher": "^2.5.1",
+        "multipasta": "^0.2.7",
+        "ws": "^8.18.2"
+      },
+      "peerDependencies": {
+        "@effect/cluster": "^0.59.0",
+        "@effect/platform": "^0.96.1",
+        "@effect/rpc": "^0.75.1",
+        "@effect/sql": "^0.51.1",
+        "effect": "^3.21.2"
+      }
+    },
+    "node_modules/@effect/rpc": {
+      "version": "0.75.1",
+      "resolved": "https://registry.npmjs.org/@effect/rpc/-/rpc-0.75.1.tgz",
+      "integrity": "sha512-8yxF8+mMGGEbF8BUCp34HjdJj7CvTpGeZxBcpsDF6v7zPiGbJL1UDLzA8ZqYjmcngBHhPecbmeONTk/LiLAaEg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "msgpackr": "^1.11.10"
+      },
+      "peerDependencies": {
+        "@effect/platform": "^0.96.1",
+        "effect": "^3.21.2"
+      }
+    },
+    "node_modules/@effect/sql": {
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@effect/sql/-/sql-0.51.1.tgz",
+      "integrity": "sha512-iPDAefrJcI0HcTk9keP9Gq8Pg08K1HmpnmZZt85AqyTcvorhoNsXDFiKBbPldfV2CortwVkacX8KjO9GPpSYCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "uuid": "^11.0.3"
+      },
+      "peerDependencies": {
+        "@effect/experimental": "^0.60.0",
+        "@effect/platform": "^0.96.1",
+        "effect": "^3.21.2"
+      }
+    },
+    "node_modules/@effect/workflow": {
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@effect/workflow/-/workflow-0.18.2.tgz",
+      "integrity": "sha512-2av0TexhxHnapQa3eLn6TkniokUFRZKf8dlWlLqbODMpXAJ3mm+DOHWM0ozMGkg9K/+zGCtiL3dMqJyJ8r7G8g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@effect/experimental": "^0.60.0",
+        "@effect/platform": "^0.96.1",
+        "@effect/rpc": "^0.75.1",
+        "effect": "^3.21.2"
+      }
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@prudentbird/voxx": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@prudentbird/voxx/-/voxx-1.1.0.tgz",
+      "integrity": "sha512-WSEtpcwp+uUQv5WKA2yOJERAJRWcYjM8pWmpJdfUc4hG1queRQsmkTqLA/QyyyDCVMKdKG0jgcHdo2lM5jYZxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@prudentbird/voxx-core": "1.1.0"
+      },
+      "bin": {
+        "voxx": "dist/index.mjs"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@prudentbird/voxx-core": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@prudentbird/voxx-core/-/voxx-core-1.1.0.tgz",
+      "integrity": "sha512-iZb5WvLPMjhcs2YqwZywEtBffVYM58E6BE1J4b+2ZKkr0hsRri6Mn/+pqxnEEiCKaA9eIyMBTUXx4x1ZSUWPRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@effect/platform": "^0.96.1",
+        "@effect/platform-node": "^0.107.0",
+        "@shikijs/rehype": "^4.2.0",
+        "effect": "^3.21.3",
+        "gray-matter": "^4.0.3",
+        "hast-util-to-string": "^3.0.1",
+        "rehype-autolink-headings": "^7.1.0",
+        "rehype-raw": "^7.0.0",
+        "rehype-slug": "^6.0.0",
+        "rehype-stringify": "^10.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "shiki": "^4.2.0",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/core": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.2.0.tgz",
+      "integrity": "sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.2.0",
+        "@shikijs/types": "4.2.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.2.0.tgz",
+      "integrity": "sha512-fjETeq1k5ffyXqRgS6+3hpvqseLalp1kjNfRbXpUgWR8FpZ1CmQfiNHovc5lncYjt/Vg5JK/WJEmLahjwMa0og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.2.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.2.0.tgz",
+      "integrity": "sha512-hTorK1dffPkpbMUk6Z+828PgRo7d07HbnizoP0hNPFjhxMHctj0Px/qoHeGMYafc6ju+u9iMldN4JbVzNQM++g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.2.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.2.0.tgz",
+      "integrity": "sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.2.0.tgz",
+      "integrity": "sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.2.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/rehype": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/rehype/-/rehype-4.2.0.tgz",
+      "integrity": "sha512-ST3EWye/dwF1gWskczJNBnwFtDzEQ9ceytXZtyc/GfwR5V0qJrkoSGZO55O3SAKDDsXkTDcsfwd9pVe7ROlAHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.2.0",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-string": "^3.0.1",
+        "shiki": "4.2.0",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.2.0.tgz",
+      "integrity": "sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.2.0.tgz",
+      "integrity": "sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/effect": {
+      "version": "3.21.3",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.3.tgz",
+      "integrity": "sha512-RqwU7WnJ6CqYhyjpOVJA5vh1Sgkn6eVECO6mnD0EjlbWcC2M3LJaPglXXr13Rdo/Y+B+wTEPzGRYFNL2xKxNeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/find-my-way-ts": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-heading-rank": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
+      "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "hast-util-to-parse5": "^8.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "parse5": "^7.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/kubernetes-types": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
+      "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/msgpackr": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.12.1.tgz",
+      "integrity": "sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+      }
+    },
+    "node_modules/multipasta": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
+      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rehype-autolink-headings": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/rehype-autolink-headings/-/rehype-autolink-headings-7.1.0.tgz",
+      "integrity": "sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-raw": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-raw": "^9.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-slug": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
+      "integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "github-slugger": "^2.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-stringify": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+      "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.2.0.tgz",
+      "integrity": "sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.2.0",
+        "@shikijs/engine-javascript": "4.2.0",
+        "@shikijs/engine-oniguruma": "4.2.0",
+        "@shikijs/langs": "4.2.0",
+        "@shikijs/themes": "4.2.0",
+        "@shikijs/types": "4.2.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
+      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/blog/package.json
+++ b/blog/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@ajared/blog",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "voxx dev",
+    "build": "voxx build --out .."
+  },
+  "devDependencies": {
+    "@prudentbird/voxx": "^1.1.0",
+    "@prudentbird/voxx-core": "^1.1.0"
+  }
+}

--- a/blog/rss.xml
+++ b/blog/rss.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    <title>Ajared Research</title>
+    <link>https://ajared.ca</link>
+    <description>Engineering and strategy notes from the Ajared Research team.</description>
+    <language>en-US</language>
+    <lastBuildDate>Sat, 13 Jun 2026 00:00:00 GMT</lastBuildDate>
+    <atom:link href="https://ajared.ca/blog/rss.xml" rel="self" type="application/rss+xml"/>
+    <item>
+      <title>Hello, world</title>
+      <link>https://ajared.ca/blog/hello-world</link>
+      <guid isPermaLink="true">https://ajared.ca/blog/hello-world</guid>
+      <pubDate>Sat, 13 Jun 2026 00:00:00 GMT</pubDate>
+      <description>Your very first Voxx post — edit or delete me.</description>
+      <content:encoded><![CDATA[<p>Welcome to your new blog. This file is just markdown with a little YAML
+frontmatter on top, so you can write a post in any editor and commit it like
+code.</p>
+<h2 id="why-json-was-the-wrong-surface"><a href="#why-json-was-the-wrong-surface">Why JSON was the wrong surface</a></h2>
+<p>Configuration files are great for machines and miserable for writing. Prose
+wants to be prose — headings, paragraphs, the occasional list:</p>
+<ul>
+<li>No database to run</li>
+<li>No admin UI to log into</li>
+<li>Just files you can grep, diff, and version</li>
+</ul>
+<h2 id="one-line-thats-all"><a href="#one-line-thats-all">One line, that's all</a></h2>
+<p>Voxx reads this file, parses the frontmatter, renders the markdown, and hands
+your app clean data. Code blocks are highlighted automatically:</p>
+<pre class="shiki shiki-themes github-light github-dark" style="--shiki-light:#24292e;--shiki-dark:#e1e4e8;--shiki-light-bg:#fff;--shiki-dark-bg:#24292e" tabindex="0"><code><span class="line"><span style="--shiki-light:#D73A49;--shiki-dark:#F97583">import</span><span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8"> { getPosts } </span><span style="--shiki-light:#D73A49;--shiki-dark:#F97583">from</span><span style="--shiki-light:#032F62;--shiki-dark:#9ECBFF"> "@prudentbird/voxx-core"</span><span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8">;</span></span>
+<span class="line"></span>
+<span class="line"><span style="--shiki-light:#D73A49;--shiki-dark:#F97583">const</span><span style="--shiki-light:#005CC5;--shiki-dark:#79B8FF"> posts</span><span style="--shiki-light:#D73A49;--shiki-dark:#F97583"> =</span><span style="--shiki-light:#D73A49;--shiki-dark:#F97583"> await</span><span style="--shiki-light:#6F42C1;--shiki-dark:#B392F0"> getPosts</span><span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8">();</span></span></code></pre>
+<h2 id="a-format-that-plays-well-with-ai"><a href="#a-format-that-plays-well-with-ai">A format that plays well with AI</a></h2>
+<p>Because every post is self-describing — explicit metadata, natural-language
+body — both humans and agents can read and write them. Voxx can even emit an
+<code>llms.txt</code> so models can discover your writing.</p>
+<h2 id="final-thoughts"><a href="#final-thoughts">Final thoughts</a></h2>
+<p>Edit <code>voxx.json</code> to configure the blog, drop more <code>.md</code> files next to this one,
+and you're publishing. That's the whole idea.</p>]]></content:encoded>
+      <category>getting-started</category>
+    </item>
+  </channel>
+</rss>

--- a/blog/voxx.json
+++ b/blog/voxx.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "./node_modules/@prudentbird/voxx-core/voxx.schema.json",
+  "site": {
+    "title": "Ajared Research",
+    "description": "Engineering and strategy notes from the Ajared Research team.",
+    "url": "https://ajared.ca",
+    "titleHref": "/",
+    "author": { "name": "Ajared Research Inc.", "url": "https://ajared.ca" },
+    "locale": "en-US"
+  },
+  "content": {
+    "type": "blog",
+    "dir": "content",
+    "basePath": "/blog",
+    "drafts": false
+  },
+  "theme": {
+    "preset": "shadcn",
+    "css": null,
+    "codeTheme": "github-light github-dark"
+  },
+  "features": {
+    "toc": true,
+    "rss": true,
+    "sitemap": false,
+    "llmsTxt": false,
+    "tags": true,
+    "readingTime": true
+  },
+  "seo": {
+    "openGraph": true,
+    "twitter": "@ajaredia",
+    "jsonLd": true,
+    "defaultImage": null
+  }
+}

--- a/capabilities/001-applied-research.html
+++ b/capabilities/001-applied-research.html
@@ -1,6 +1,7 @@
-<!DOCTYPE html SYSTEM "about:legacy-compat">
+<!DOCTYPE html>
 <html lang="en">
 <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
@@ -12,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/favicon-32x32.png">
-<title>Applied Research &#8212; Ajared Research Inc</title>
+<title>Applied Research — Ajared Research Inc</title>
 <style>
         /* iA Writer Quattro S Font */
         @font-face {
@@ -245,7 +246,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             font-size: 1rem;
         }
 
-        /* Change 11: Nav hover &#8212; terra cotta */
+        /* Change 11: Nav hover — terra cotta */
         nav a:hover {
             text-decoration: underline;
             color: var(--color-terra);
@@ -301,7 +302,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             pointer-events: none;
         }
 
-        /* Change 10: Secondary ripple rings &#8212; subtle terra cotta tint */
+        /* Change 10: Secondary ripple rings — subtle terra cotta tint */
         .ripple-secondary {
             position: absolute;
             border-radius: 50%;
@@ -361,7 +362,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             margin-bottom: 0.5rem;
         }
 
-        /* Arrow &#8212; Change 3: terra cotta by default */
+        /* Arrow — Change 3: terra cotta by default */
         .arrow-icon {
             width: 40px;
             height: 1px;
@@ -394,7 +395,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             border-right-color: var(--color-bg);
         }
 
-        /* Stretched link &#8212; entire card is clickable */
+        /* Stretched link — entire card is clickable */
         .service-card > a {
             position: static;
         }
@@ -404,7 +405,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             inset: 0;
         }
 
-        /* Button &#8212; Change 1: terra cotta border + text, fills on hover */
+        /* Button — Change 1: terra cotta border + text, fills on hover */
         .btn {
             display: inline-block;
             margin-top: 2rem;
@@ -550,7 +551,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             color: var(--color-bg);
         }
 
-        /* Offer card tracks (card 03 &#8212; Get Started with AI) */
+        /* Offer card tracks (card 03 — Get Started with AI) */
         .track-list {
             margin-top: 1rem;
             display: flex;
@@ -747,7 +748,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         .hero-detail-content { position: relative; z-index: 1; }
         .hero-detail h1 { font-family: var(--font-primary); font-size: clamp(1.8rem, 3.5vw, 3.2rem); font-weight: 700; letter-spacing: -0.045em; line-height: 0.95; color: #fff; margin-bottom: 0; }
         
-        /* &#9472;&#9472; Essay + Marginalia layout (capability detail pages) &#9472;&#9472;&#9472; */
+        /* ── Essay + Marginalia layout (capability detail pages) ─── */
         .page-body { border-bottom: var(--grid-line); }
 
         .essay-section {
@@ -902,7 +903,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         .cta-btn { font-family: var(--font-mono); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--color-terra); border: 2px solid var(--color-terra); padding: 0.9rem 1.8rem; transition: background 0.2s, color 0.2s; white-space: nowrap; background: transparent; }
         .cta-btn:hover { background: var(--color-terra); color: #fff; }
 
-        /* &#9472;&#9472; Deliverable List &#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472; */
+        /* ── Deliverable List ─────────────────────────────────── */
         .deliverable-list { border-top: var(--grid-line); }
         .deliverable-row {
             display: grid;
@@ -1064,18 +1065,18 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <div class="header-cell" style="padding: 0.9rem 1.2rem; justify-content: center;"><div class="nav-crumb">
 <a href="/capabilities/" style="color:inherit;text-decoration:none;">Capabilities</a><span class="sep">/</span><span class="cur">Applied Research</span>
 </div></div>
-<div class="header-cell" style="padding: 0.9rem 1.2rem; align-items: center; justify-content: center;"><nav style="display: flex; gap: 1.8rem;"><a href="/" style="font-size: 0.72rem;">Index</a><a href="/case-studies/" style="font-size: 0.72rem;">Case Studies</a><a href="/capabilities/" style="font-size: 0.72rem;">Capabilities</a><a href="/contact/" style="font-size: 0.72rem;">Contact</a><a href="https://www.ajared.ng" style="font-size: 0.72rem;">Read</a></nav></div></header><div class="hero-detail">
+<div class="header-cell" style="padding: 0.9rem 1.2rem; align-items: center; justify-content: center;"><nav style="display: flex; gap: 1.8rem;"><a href="/" style="font-size: 0.72rem;">Index</a><a href="/case-studies/" style="font-size: 0.72rem;">Case Studies</a><a href="/capabilities/" style="font-size: 0.72rem;">Capabilities</a><a href="/contact/" style="font-size: 0.72rem;">Contact</a><a href="/blog/" style="font-size: 0.72rem;">Blog</a><a href="https://www.ajared.ng" style="font-size: 0.72rem;">Read</a></nav></div></header><div class="hero-detail">
 <canvas class="hero-detail-moire" id="heroMoire"></canvas><div class="hero-detail-content"><h1>Applied Research</h1></div>
 </div>
 <div class="page-body">
 <div class="essay-section">
 <div class="essay-section-label">What We Do</div>
 <div class="essay-main">
-        <p>We figure out what&#8217;s actually going on before anyone starts building. That means talking to users, studying the market, and testing ideas against reality. We draw on behavioural science, statistics, and deep domain knowledge to produce findings your team can act on with confidence.</p>
+        <p>We figure out what’s actually going on before anyone starts building. That means talking to users, studying the market, and testing ideas against reality. We draw on behavioural science, statistics, and deep domain knowledge to produce findings your team can act on with confidence.</p>
       <div class="essay-offerings">
-<p class="essay-offering-para"><strong>UX Research</strong>&#160;&#8212;&#160;We go to where your users are &#8212; interviews, diary studies, usability tests, in-context observation. The goal is understanding what people actually do, not just what they say, so the product decisions that follow are grounded in reality.</p>
-<p class="essay-offering-para"><strong>Market Research</strong>&#160;&#8212;&#160;A clear picture of the landscape before you move. Competitive analysis, market sizing, audience segmentation, and trend mapping &#8212; so you know exactly where the opportunity is, what you&#8217;re up against, and what the data won&#8217;t yet tell you.</p>
-<p class="essay-offering-para"><strong>Testing Business Ideas</strong>&#160;&#8212;&#160;Most assumptions are wrong. We design lean experiments &#8212; demand tests, concierge MVPs, assumption mapping, causal inference &#8212; that expose which ones to kill early and which ones to build around. Early failure is cheap. Late failure is not.</p>
+<p class="essay-offering-para"><strong>UX Research</strong> — We go to where your users are — interviews, diary studies, usability tests, in-context observation. The goal is understanding what people actually do, not just what they say, so the product decisions that follow are grounded in reality.</p>
+<p class="essay-offering-para"><strong>Market Research</strong> — A clear picture of the landscape before you move. Competitive analysis, market sizing, audience segmentation, and trend mapping — so you know exactly where the opportunity is, what you’re up against, and what the data won’t yet tell you.</p>
+<p class="essay-offering-para"><strong>Testing Business Ideas</strong> — Most assumptions are wrong. We design lean experiments — demand tests, concierge MVPs, assumption mapping, causal inference — that expose which ones to kill early and which ones to build around. Early failure is cheap. Late failure is not.</p>
 </div>
 </div>
 <div class="sidenote">
@@ -1094,7 +1095,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <li>
 <strong>Analysis</strong>Raw data becomes structured insight. We code qualitative findings, run statistical checks where the data supports it, look for converging patterns, and stress-test conclusions before committing to them.</li>
 <li>
-<strong>Delivery</strong>Findings land in a plain-language report, an executive presentation deck, and a documented methodology archive &#8212; built for the people who need to act on them, not for the people who already know the answer.</li>
+<strong>Delivery</strong>Findings land in a plain-language report, an executive presentation deck, and a documented methodology archive — built for the people who need to act on them, not for the people who already know the answer.</li>
 </ol></div>
 <div class="sidenote">
 <span class="sidenote-heading">Steps</span><div class="sidenote-item">
@@ -1110,7 +1111,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <div class="essay-section">
 <div class="essay-section-label">Deliverables</div>
 <div class="essay-main">
-        <p>Every engagement closes with documents designed to survive handoff &#8212; a research brief, a plain-language findings report, an executive presentation deck, and a full evidence archive with methodology notes. Teams that want continuity can extend into an ongoing research retainer.</p>
+        <p>Every engagement closes with documents designed to survive handoff — a research brief, a plain-language findings report, an executive presentation deck, and a full evidence archive with methodology notes. Teams that want continuity can extend into an ongoing research retainer.</p>
       </div>
 <div class="sidenote">
 <span class="sidenote-heading">Included</span><div class="sidenote-item">Research brief</div>
@@ -1122,18 +1123,18 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </div>
 </div>
 <div class="cap-nav">
-<a href="/capabilities/004-data-strategy.html" class="cap-nav-prev">&#8592; Data &amp; AI Strategy</a><a href="/capabilities/" class="cap-nav-center">All Capabilities</a><a href="/capabilities/002-ai-product.html" class="cap-nav-next">Product Development &#8594;</a>
+<a href="/capabilities/004-data-strategy.html" class="cap-nav-prev">← Data &amp; AI Strategy</a><a href="/capabilities/" class="cap-nav-center">All Capabilities</a><a href="/capabilities/002-ai-product.html" class="cap-nav-next">Product Development →</a>
 </div>
 <div class="cta-block">
-<div><h3>Ready to find out what&#8217;s true?</h3></div>
-<a href="/contact/" style="text-decoration:none;"><div class="cta-btn">Get in touch &#8594;</div></a>
+<div><h3>Ready to find out what’s true?</h3></div>
+<a href="/contact/" style="text-decoration:none;"><div class="cta-btn">Get in touch →</div></a>
 </div>
 <div class="footer">
 <div>
 <span class="label" style="color: var(--color-terra);">Inquiries</span><h2><a href="mailto:innovation@ajared.ca">innovation@<span style="color: #a1665e;">aja</span>red.ca</a></h2>
 </div>
 <div style="text-align:right; display:flex; flex-direction:column; justify-content:center; align-items:flex-end; gap:0.5rem;">
-<p>&#169; 2026 Ajared Research Inc.</p>
+<p>© 2026 Ajared Research Inc.</p>
 <span class="label">R<span style="color:#a1665e">e</span>s<span style="color:#a1665e">ea</span>rch,
                 <span style="color:#a1665e">e</span>d<span style="color:#a1665e">u</span>c<span style="color:#a1665e">a</span>t<span style="color:#a1665e">e</span>, d<span style="color:#a1665e">e</span>s<span style="color:#a1665e">i</span>gn.</span>
 </div>

--- a/capabilities/002-ai-product.html
+++ b/capabilities/002-ai-product.html
@@ -1,6 +1,7 @@
-<!DOCTYPE html SYSTEM "about:legacy-compat">
+<!DOCTYPE html>
 <html lang="en">
 <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
@@ -12,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/favicon-32x32.png">
-<title>Product Development &#8212; Ajared Research Inc</title>
+<title>Product Development — Ajared Research Inc</title>
 <style>
         /* iA Writer Quattro S Font */
         @font-face {
@@ -245,7 +246,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             font-size: 1rem;
         }
 
-        /* Change 11: Nav hover &#8212; terra cotta */
+        /* Change 11: Nav hover — terra cotta */
         nav a:hover {
             text-decoration: underline;
             color: var(--color-terra);
@@ -301,7 +302,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             pointer-events: none;
         }
 
-        /* Change 10: Secondary ripple rings &#8212; subtle terra cotta tint */
+        /* Change 10: Secondary ripple rings — subtle terra cotta tint */
         .ripple-secondary {
             position: absolute;
             border-radius: 50%;
@@ -361,7 +362,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             margin-bottom: 0.5rem;
         }
 
-        /* Arrow &#8212; Change 3: terra cotta by default */
+        /* Arrow — Change 3: terra cotta by default */
         .arrow-icon {
             width: 40px;
             height: 1px;
@@ -394,7 +395,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             border-right-color: var(--color-bg);
         }
 
-        /* Stretched link &#8212; entire card is clickable */
+        /* Stretched link — entire card is clickable */
         .service-card > a {
             position: static;
         }
@@ -404,7 +405,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             inset: 0;
         }
 
-        /* Button &#8212; Change 1: terra cotta border + text, fills on hover */
+        /* Button — Change 1: terra cotta border + text, fills on hover */
         .btn {
             display: inline-block;
             margin-top: 2rem;
@@ -550,7 +551,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             color: var(--color-bg);
         }
 
-        /* Offer card tracks (card 03 &#8212; Get Started with AI) */
+        /* Offer card tracks (card 03 — Get Started with AI) */
         .track-list {
             margin-top: 1rem;
             display: flex;
@@ -747,7 +748,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         .hero-detail-content { position: relative; z-index: 1; }
         .hero-detail h1 { font-family: var(--font-primary); font-size: clamp(1.8rem, 3.5vw, 3.2rem); font-weight: 700; letter-spacing: -0.045em; line-height: 0.95; color: #fff; margin-bottom: 0; }
         
-        /* &#9472;&#9472; Essay + Marginalia layout (capability detail pages) &#9472;&#9472;&#9472; */
+        /* ── Essay + Marginalia layout (capability detail pages) ─── */
         .page-body { border-bottom: var(--grid-line); }
 
         .essay-section {
@@ -902,7 +903,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         .cta-btn { font-family: var(--font-mono); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--color-terra); border: 2px solid var(--color-terra); padding: 0.9rem 1.8rem; transition: background 0.2s, color 0.2s; white-space: nowrap; background: transparent; }
         .cta-btn:hover { background: var(--color-terra); color: #fff; }
 
-        /* &#9472;&#9472; Deliverable List &#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472; */
+        /* ── Deliverable List ─────────────────────────────────── */
         .deliverable-list { border-top: var(--grid-line); }
         .deliverable-row {
             display: grid;
@@ -1059,7 +1060,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <div class="header-cell" style="padding: 0.9rem 1.2rem; justify-content: center;"><div class="nav-crumb">
 <a href="/capabilities/" style="color:inherit;text-decoration:none;">Capabilities</a><span class="sep">/</span><span class="cur">Product Development</span>
 </div></div>
-<div class="header-cell" style="padding: 0.9rem 1.2rem; align-items: center; justify-content: center;"><nav style="display: flex; gap: 1.8rem;"><a href="/" style="font-size: 0.72rem;">Index</a><a href="/case-studies/" style="font-size: 0.72rem;">Case Studies</a><a href="/capabilities/" style="font-size: 0.72rem;">Capabilities</a><a href="/contact/" style="font-size: 0.72rem;">Contact</a><a href="https://www.ajared.ng" style="font-size: 0.72rem;">Read</a></nav></div></header><div class="hero-detail">
+<div class="header-cell" style="padding: 0.9rem 1.2rem; align-items: center; justify-content: center;"><nav style="display: flex; gap: 1.8rem;"><a href="/" style="font-size: 0.72rem;">Index</a><a href="/case-studies/" style="font-size: 0.72rem;">Case Studies</a><a href="/capabilities/" style="font-size: 0.72rem;">Capabilities</a><a href="/contact/" style="font-size: 0.72rem;">Contact</a><a href="/blog/" style="font-size: 0.72rem;">Blog</a><a href="https://www.ajared.ng" style="font-size: 0.72rem;">Read</a></nav></div></header><div class="hero-detail">
 <canvas class="hero-detail-moire" id="heroMoire"></canvas><div class="hero-detail-content"><h1>Product Development</h1></div>
 </div>
 <div class="page-body">
@@ -1067,20 +1068,20 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <div class="essay-section-label">What We Do</div>
 <div class="essay-main">
         <p>We help you build products and keep them running. That covers everything from the first idea through
-              launch, growth, and the ongoing work of making them better &#8212; concept development, UX design, product
+              launch, growth, and the ongoing work of making them better — concept development, UX design, product
               management, and full-stack engineering under one roof.</p>
       <div class="essay-offerings">
-<p class="essay-offering-para"><strong>Concept Development</strong>&#160;&#8212;&#160;From rough idea to defined product. We run structured workshops to frame the opportunity,
-                  pressure-test the underlying assumptions, assess feasibility, and set the strategic positioning &#8212; so
+<p class="essay-offering-para"><strong>Concept Development</strong> — From rough idea to defined product. We run structured workshops to frame the opportunity,
+                  pressure-test the underlying assumptions, assess feasibility, and set the strategic positioning — so
                   design and engineering start with a foundation that holds up.</p>
-<p class="essay-offering-para"><strong>Design Thinking</strong>&#160;&#8212;&#160;Research-led UX built from first principles. We map information architecture, design interaction
-                  flows, prototype at the right fidelity, and test with real users iteratively &#8212; so the product feels
+<p class="essay-offering-para"><strong>Design Thinking</strong> — Research-led UX built from first principles. We map information architecture, design interaction
+                  flows, prototype at the right fidelity, and test with real users iteratively — so the product feels
                   right before production engineering begins.</p>
-<p class="essay-offering-para"><strong>Product Management</strong>&#160;&#8212;&#160;The connective tissue between vision and execution. We set the roadmap, define OKRs, manage
-                  prioritisation trade-offs, align stakeholders, and coordinate go-to-market &#8212; so the team stays pointed
+<p class="essay-offering-para"><strong>Product Management</strong> — The connective tissue between vision and execution. We set the roadmap, define OKRs, manage
+                  prioritisation trade-offs, align stakeholders, and coordinate go-to-market — so the team stays pointed
                   at the right problem at the right time.</p>
-<p class="essay-offering-para"><strong>AI-Powered Engineering</strong>&#160;&#8212;&#160;Full-stack development augmented by AI tooling. API integration, backend services, front-end
-                  interfaces, QA, and deployment &#8212; built for production and long-term operability, not for demos that
+<p class="essay-offering-para"><strong>AI-Powered Engineering</strong> — Full-stack development augmented by AI tooling. API integration, backend services, front-end
+                  interfaces, QA, and deployment — built for production and long-term operability, not for demos that
                   work once under ideal conditions.</p>
 </div>
 </div>
@@ -1099,13 +1100,13 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                     that every subsequent decision has a reference point to return to.</li>
 <li>
 <strong>Design</strong>Concept development feeds directly into UX design, prototyping, and user validation. We test with
-                    real people before writing a line of production code &#8212; catching misaligned assumptions when they&#8217;re
+                    real people before writing a line of production code — catching misaligned assumptions when they’re
                     still cheap to fix.</li>
 <li>
 <strong>Build</strong>Iterative development cycles with continuous QA, integration testing, and performance tuning. We
                     ship incrementally to reduce risk and maintain feedback loops throughout the build.</li>
 <li>
-<strong>Launch</strong>Staged rollout with monitoring instrumentation in place from the start &#8212; not added after something
+<strong>Launch</strong>Staged rollout with monitoring instrumentation in place from the start — not added after something
                     breaks. Analytics, alerting, and a structured feedback loop that feeds the next iteration.</li>
 </ol></div>
 <div class="sidenote">
@@ -1122,7 +1123,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <div class="essay-section">
 <div class="essay-section-label">Deliverables</div>
 <div class="essay-main">
-        <p>The engagement closes with a complete product package &#8212; concept brief, strategy, and roadmap through to a UX design system with tested prototypes and a production-ready working product. Launch plan and analytics instrumentation are included as standard, along with a one-month MVP sprint. Teams that want ongoing ownership support can extend into a fractional product management retainer.</p>
+        <p>The engagement closes with a complete product package — concept brief, strategy, and roadmap through to a UX design system with tested prototypes and a production-ready working product. Launch plan and analytics instrumentation are included as standard, along with a one-month MVP sprint. Teams that want ongoing ownership support can extend into a fractional product management retainer.</p>
       </div>
 <div class="sidenote">
 <span class="sidenote-heading">Included</span><div class="sidenote-item">Concept brief + roadmap</div>
@@ -1135,18 +1136,18 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </div>
 </div>
 <div class="cap-nav">
-<a href="/capabilities/001-applied-research.html" class="cap-nav-prev">&#8592; Applied Research</a><a href="/capabilities/" class="cap-nav-center">All Capabilities</a><a href="/capabilities/003-enterprise-agents.html" class="cap-nav-next">Enterprise AI Agents &#8594;</a>
+<a href="/capabilities/001-applied-research.html" class="cap-nav-prev">← Applied Research</a><a href="/capabilities/" class="cap-nav-center">All Capabilities</a><a href="/capabilities/003-enterprise-agents.html" class="cap-nav-next">Enterprise AI Agents →</a>
 </div>
 <div class="cta-block">
 <div><h3>Ready to build something that works?</h3></div>
-<a href="/contact/" style="text-decoration:none;"><div class="cta-btn">Get in touch &#8594;</div></a>
+<a href="/contact/" style="text-decoration:none;"><div class="cta-btn">Get in touch →</div></a>
 </div>
 <div class="footer">
 <div>
 <span class="label" style="color: var(--color-terra);">Inquiries</span><h2><a href="mailto:innovation@ajared.ca">innovation@<span style="color: #a1665e;">aja</span>red.ca</a></h2>
 </div>
 <div style="text-align:right; display:flex; flex-direction:column; justify-content:center; align-items:flex-end; gap:0.5rem;">
-<p>&#169; 2026 Ajared Research Inc.</p>
+<p>© 2026 Ajared Research Inc.</p>
 <span class="label">R<span style="color:#a1665e">e</span>s<span style="color:#a1665e">ea</span>rch,
                 <span style="color:#a1665e">e</span>d<span style="color:#a1665e">u</span>c<span style="color:#a1665e">a</span>t<span style="color:#a1665e">e</span>, d<span style="color:#a1665e">e</span>s<span style="color:#a1665e">i</span>gn.</span>
 </div>

--- a/capabilities/003-enterprise-agents.html
+++ b/capabilities/003-enterprise-agents.html
@@ -1,6 +1,7 @@
-<!DOCTYPE html SYSTEM "about:legacy-compat">
+<!DOCTYPE html>
 <html lang="en">
 <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
@@ -12,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/favicon-32x32.png">
-<title>Enterprise AI Agents &#8212; Ajared Research Inc</title>
+<title>Enterprise AI Agents — Ajared Research Inc</title>
 <style>
         /* iA Writer Quattro S Font */
         @font-face {
@@ -245,7 +246,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             font-size: 1rem;
         }
 
-        /* Change 11: Nav hover &#8212; terra cotta */
+        /* Change 11: Nav hover — terra cotta */
         nav a:hover {
             text-decoration: underline;
             color: var(--color-terra);
@@ -301,7 +302,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             pointer-events: none;
         }
 
-        /* Change 10: Secondary ripple rings &#8212; subtle terra cotta tint */
+        /* Change 10: Secondary ripple rings — subtle terra cotta tint */
         .ripple-secondary {
             position: absolute;
             border-radius: 50%;
@@ -361,7 +362,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             margin-bottom: 0.5rem;
         }
 
-        /* Arrow &#8212; Change 3: terra cotta by default */
+        /* Arrow — Change 3: terra cotta by default */
         .arrow-icon {
             width: 40px;
             height: 1px;
@@ -394,7 +395,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             border-right-color: var(--color-bg);
         }
 
-        /* Stretched link &#8212; entire card is clickable */
+        /* Stretched link — entire card is clickable */
         .service-card > a {
             position: static;
         }
@@ -404,7 +405,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             inset: 0;
         }
 
-        /* Button &#8212; Change 1: terra cotta border + text, fills on hover */
+        /* Button — Change 1: terra cotta border + text, fills on hover */
         .btn {
             display: inline-block;
             margin-top: 2rem;
@@ -550,7 +551,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             color: var(--color-bg);
         }
 
-        /* Offer card tracks (card 03 &#8212; Get Started with AI) */
+        /* Offer card tracks (card 03 — Get Started with AI) */
         .track-list {
             margin-top: 1rem;
             display: flex;
@@ -747,7 +748,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         .hero-detail-content { position: relative; z-index: 1; }
         .hero-detail h1 { font-family: var(--font-primary); font-size: clamp(1.8rem, 3.5vw, 3.2rem); font-weight: 700; letter-spacing: -0.045em; line-height: 0.95; color: #fff; margin-bottom: 0; }
         
-        /* &#9472;&#9472; Essay + Marginalia layout (capability detail pages) &#9472;&#9472;&#9472; */
+        /* ── Essay + Marginalia layout (capability detail pages) ─── */
         .page-body { border-bottom: var(--grid-line); }
 
         .essay-section {
@@ -902,7 +903,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         .cta-btn { font-family: var(--font-mono); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--color-terra); border: 2px solid var(--color-terra); padding: 0.9rem 1.8rem; transition: background 0.2s, color 0.2s; white-space: nowrap; background: transparent; }
         .cta-btn:hover { background: var(--color-terra); color: #fff; }
 
-        /* &#9472;&#9472; Deliverable List &#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472; */
+        /* ── Deliverable List ─────────────────────────────────── */
         .deliverable-list { border-top: var(--grid-line); }
         .deliverable-row {
             display: grid;
@@ -1059,25 +1060,25 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <div class="header-cell" style="padding: 0.9rem 1.2rem; justify-content: center;"><div class="nav-crumb">
 <a href="/capabilities/" style="color:inherit;text-decoration:none;">Capabilities</a><span class="sep">/</span><span class="cur">Enterprise Agents</span>
 </div></div>
-<div class="header-cell" style="padding: 0.9rem 1.2rem; align-items: center; justify-content: center;"><nav style="display: flex; gap: 1.8rem;"><a href="/" style="font-size: 0.72rem;">Index</a><a href="/case-studies/" style="font-size: 0.72rem;">Case Studies</a><a href="/capabilities/" style="font-size: 0.72rem;">Capabilities</a><a href="/contact/" style="font-size: 0.72rem;">Contact</a><a href="https://www.ajared.ng" style="font-size: 0.72rem;">Read</a></nav></div></header><div class="hero-detail">
+<div class="header-cell" style="padding: 0.9rem 1.2rem; align-items: center; justify-content: center;"><nav style="display: flex; gap: 1.8rem;"><a href="/" style="font-size: 0.72rem;">Index</a><a href="/case-studies/" style="font-size: 0.72rem;">Case Studies</a><a href="/capabilities/" style="font-size: 0.72rem;">Capabilities</a><a href="/contact/" style="font-size: 0.72rem;">Contact</a><a href="/blog/" style="font-size: 0.72rem;">Blog</a><a href="https://www.ajared.ng" style="font-size: 0.72rem;">Read</a></nav></div></header><div class="hero-detail">
 <canvas class="hero-detail-moire" id="heroMoire"></canvas><div class="hero-detail-content"><h1>Enterprise AI Agents</h1></div>
 </div>
 <div class="page-body">
 <div class="essay-section">
 <div class="essay-section-label">What We Do</div>
 <div class="essay-main">
-        <p>We build AI agents that handle real tasks &#8212; processing documents, coordinating between systems, making
+        <p>We build AI agents that handle real tasks — processing documents, coordinating between systems, making
               routine decisions at scale. Built for production, not for demos. So your team can focus on the work that
               actually needs a human.</p>
       <div class="essay-offerings">
-<p class="essay-offering-para"><strong>AI Agents</strong>&#160;&#8212;&#160;Task-specific agents built for production. We design agents with the right tools, memory
-                  architecture, and decision logic to handle real workflows reliably at scale &#8212; with human oversight
+<p class="essay-offering-para"><strong>AI Agents</strong> — Task-specific agents built for production. We design agents with the right tools, memory
+                  architecture, and decision logic to handle real workflows reliably at scale — with human oversight
                   integrated where it matters, not added as an afterthought.</p>
-<p class="essay-offering-para"><strong>Graph RAG</strong>&#160;&#8212;&#160;When your data is too interconnected for flat retrieval. We build knowledge graph-augmented RAG
+<p class="essay-offering-para"><strong>Graph RAG</strong> — When your data is too interconnected for flat retrieval. We build knowledge graph-augmented RAG
                   systems that navigate entity relationships, surface precise answers from complex enterprise data
                   structures, and dramatically reduce hallucination risk.</p>
-<p class="essay-offering-para"><strong>Task Automation</strong>&#160;&#8212;&#160;End-to-end workflow automation across your existing systems. Document ingestion, routing decisions,
-                  multi-system coordination &#8212; designed to handle volume and edge cases without requiring constant human
+<p class="essay-offering-para"><strong>Task Automation</strong> — End-to-end workflow automation across your existing systems. Document ingestion, routing decisions,
+                  multi-system coordination — designed to handle volume and edge cases without requiring constant human
                   intervention to stay on track.</p>
 </div>
 </div>
@@ -1096,15 +1097,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                     causes more problems than it solves.</li>
 <li>
 <strong>Design</strong>Agent architecture, tool selection, memory design, and constraint definition. We specify the system
-                    completely before building &#8212; including how it fails gracefully and what happens when it encounters
+                    completely before building — including how it fails gracefully and what happens when it encounters
                     something outside its operating envelope.</li>
 <li>
 <strong>Build &amp; Test</strong>Development, integration with your systems, red-team evaluation, and adversarial testing. We
-                    deliberately try to break agents before deployment. An agent we haven&#8217;t stress-tested doesn&#8217;t go to
+                    deliberately try to break agents before deployment. An agent we haven’t stress-tested doesn’t go to
                     production.</li>
 <li>
 <strong>Deploy</strong>Production rollout with monitoring dashboards, alert configuration, and human-in-the-loop controls
-                    designed from the start &#8212; not bolted on after. Ongoing visibility into what the agent is doing and
+                    designed from the start — not bolted on after. Ongoing visibility into what the agent is doing and
                     why.</li>
 </ol></div>
 <div class="sidenote">
@@ -1121,7 +1122,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <div class="essay-section">
 <div class="essay-section-label">Deliverables</div>
 <div class="essay-main">
-        <p>Every agent system ships with the architecture documentation and production code, a full integration layer with API documentation, and a monitoring dashboard with alert configuration &#8212; built to run reliably without requiring constant human oversight. Teams that want us to continue running and evolving the system can extend into an ongoing operations retainer.</p>
+        <p>Every agent system ships with the architecture documentation and production code, a full integration layer with API documentation, and a monitoring dashboard with alert configuration — built to run reliably without requiring constant human oversight. Teams that want us to continue running and evolving the system can extend into an ongoing operations retainer.</p>
       </div>
 <div class="sidenote">
 <span class="sidenote-heading">Included</span><div class="sidenote-item">Architecture + system design</div>
@@ -1133,18 +1134,18 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </div>
 </div>
 <div class="cap-nav">
-<a href="/capabilities/002-ai-product.html" class="cap-nav-prev">&#8592; Product Development</a><a href="/capabilities/" class="cap-nav-center">All Capabilities</a><a href="/capabilities/004-data-strategy.html" class="cap-nav-next">Data &amp; AI Strategy &#8594;</a>
+<a href="/capabilities/002-ai-product.html" class="cap-nav-prev">← Product Development</a><a href="/capabilities/" class="cap-nav-center">All Capabilities</a><a href="/capabilities/004-data-strategy.html" class="cap-nav-next">Data &amp; AI Strategy →</a>
 </div>
 <div class="cta-block">
 <div><h3>Ready to automate the right things?</h3></div>
-<a href="/contact/" style="text-decoration:none;"><div class="cta-btn">Get in touch &#8594;</div></a>
+<a href="/contact/" style="text-decoration:none;"><div class="cta-btn">Get in touch →</div></a>
 </div>
 <div class="footer">
 <div>
 <span class="label" style="color: var(--color-terra);">Inquiries</span><h2><a href="mailto:innovation@ajared.ca">innovation@<span style="color: #a1665e;">aja</span>red.ca</a></h2>
 </div>
 <div style="text-align:right; display:flex; flex-direction:column; justify-content:center; align-items:flex-end; gap:0.5rem;">
-<p>&#169; 2026 Ajared Research Inc.</p>
+<p>© 2026 Ajared Research Inc.</p>
 <span class="label">R<span style="color:#a1665e">e</span>s<span style="color:#a1665e">ea</span>rch,
                 <span style="color:#a1665e">e</span>d<span style="color:#a1665e">u</span>c<span style="color:#a1665e">a</span>t<span style="color:#a1665e">e</span>, d<span style="color:#a1665e">e</span>s<span style="color:#a1665e">i</span>gn.</span>
 </div>

--- a/capabilities/004-data-strategy.html
+++ b/capabilities/004-data-strategy.html
@@ -1,6 +1,7 @@
-<!DOCTYPE html SYSTEM "about:legacy-compat">
+<!DOCTYPE html>
 <html lang="en">
 <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
@@ -12,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/favicon-32x32.png">
-<title>Data &amp; AI Strategy &#8212; Ajared Research Inc</title>
+<title>Data &amp; AI Strategy — Ajared Research Inc</title>
 <style>
         /* iA Writer Quattro S Font */
         @font-face {
@@ -245,7 +246,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             font-size: 1rem;
         }
 
-        /* Change 11: Nav hover &#8212; terra cotta */
+        /* Change 11: Nav hover — terra cotta */
         nav a:hover {
             text-decoration: underline;
             color: var(--color-terra);
@@ -301,7 +302,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             pointer-events: none;
         }
 
-        /* Change 10: Secondary ripple rings &#8212; subtle terra cotta tint */
+        /* Change 10: Secondary ripple rings — subtle terra cotta tint */
         .ripple-secondary {
             position: absolute;
             border-radius: 50%;
@@ -361,7 +362,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             margin-bottom: 0.5rem;
         }
 
-        /* Arrow &#8212; Change 3: terra cotta by default */
+        /* Arrow — Change 3: terra cotta by default */
         .arrow-icon {
             width: 40px;
             height: 1px;
@@ -394,7 +395,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             border-right-color: var(--color-bg);
         }
 
-        /* Stretched link &#8212; entire card is clickable */
+        /* Stretched link — entire card is clickable */
         .service-card > a {
             position: static;
         }
@@ -404,7 +405,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             inset: 0;
         }
 
-        /* Button &#8212; Change 1: terra cotta border + text, fills on hover */
+        /* Button — Change 1: terra cotta border + text, fills on hover */
         .btn {
             display: inline-block;
             margin-top: 2rem;
@@ -550,7 +551,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             color: var(--color-bg);
         }
 
-        /* Offer card tracks (card 03 &#8212; Get Started with AI) */
+        /* Offer card tracks (card 03 — Get Started with AI) */
         .track-list {
             margin-top: 1rem;
             display: flex;
@@ -747,7 +748,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         .hero-detail-content { position: relative; z-index: 1; }
         .hero-detail h1 { font-family: var(--font-primary); font-size: clamp(1.8rem, 3.5vw, 3.2rem); font-weight: 700; letter-spacing: -0.045em; line-height: 0.95; color: #fff; margin-bottom: 0; }
         
-        /* &#9472;&#9472; Essay + Marginalia layout (capability detail pages) &#9472;&#9472;&#9472; */
+        /* ── Essay + Marginalia layout (capability detail pages) ─── */
         .page-body { border-bottom: var(--grid-line); }
 
         .essay-section {
@@ -902,7 +903,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         .cta-btn { font-family: var(--font-mono); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--color-terra); border: 2px solid var(--color-terra); padding: 0.9rem 1.8rem; transition: background 0.2s, color 0.2s; white-space: nowrap; background: transparent; }
         .cta-btn:hover { background: var(--color-terra); color: #fff; }
 
-        /* &#9472;&#9472; Deliverable List &#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472; */
+        /* ── Deliverable List ─────────────────────────────────── */
         .deliverable-list { border-top: var(--grid-line); }
         .deliverable-row {
             display: grid;
@@ -1059,27 +1060,27 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <div class="header-cell" style="padding: 0.9rem 1.2rem; justify-content: center;"><div class="nav-crumb">
 <a href="/capabilities/" style="color:inherit;text-decoration:none;">Capabilities</a><span class="sep">/</span><span class="cur">Data and AI Strategy</span>
 </div></div>
-<div class="header-cell" style="padding: 0.9rem 1.2rem; align-items: center; justify-content: center;"><nav style="display: flex; gap: 1.8rem;"><a href="/" style="font-size: 0.72rem;">Index</a><a href="/case-studies/" style="font-size: 0.72rem;">Case Studies</a><a href="/capabilities/" style="font-size: 0.72rem;">Capabilities</a><a href="/contact/" style="font-size: 0.72rem;">Contact</a><a href="https://www.ajared.ng" style="font-size: 0.72rem;">Read</a></nav></div></header><div class="hero-detail">
+<div class="header-cell" style="padding: 0.9rem 1.2rem; align-items: center; justify-content: center;"><nav style="display: flex; gap: 1.8rem;"><a href="/" style="font-size: 0.72rem;">Index</a><a href="/case-studies/" style="font-size: 0.72rem;">Case Studies</a><a href="/capabilities/" style="font-size: 0.72rem;">Capabilities</a><a href="/contact/" style="font-size: 0.72rem;">Contact</a><a href="/blog/" style="font-size: 0.72rem;">Blog</a><a href="https://www.ajared.ng" style="font-size: 0.72rem;">Read</a></nav></div></header><div class="hero-detail">
 <canvas class="hero-detail-moire" id="heroMoire"></canvas><div class="hero-detail-content"><h1>Data &amp; AI Strategy</h1></div>
 </div>
 <div class="page-body">
 <div class="essay-section">
 <div class="essay-section-label">What We Do</div>
 <div class="essay-main">
-        <p>We audit your data, figure out what&#8217;s missing, and build a plan to get AI working inside your
+        <p>We audit your data, figure out what’s missing, and build a plan to get AI working inside your
               organization. That includes governance structures, realistic adoption plans, and honest assessments of
-              what you&#8217;re ready for &#8212; and what you&#8217;re not.</p>
+              what you’re ready for — and what you’re not.</p>
       <div class="essay-offerings">
-<p class="essay-offering-para"><strong>Reliable AI</strong>&#160;&#8212;&#160;AI that produces consistent, trustworthy outputs starts with structured knowledge. We build knowledge
-                  graphs and ontologies that give your AI systems a foundation they can reason from &#8212; rather than one
-                  they&#8217;re guessing around.</p>
-<p class="essay-offering-para"><strong>Location Intelligence</strong>&#160;&#8212;&#160;Spatial context changes what data means. We develop geospatial data strategies, build location-aware
+<p class="essay-offering-para"><strong>Reliable AI</strong> — AI that produces consistent, trustworthy outputs starts with structured knowledge. We build knowledge
+                  graphs and ontologies that give your AI systems a foundation they can reason from — rather than one
+                  they’re guessing around.</p>
+<p class="essay-offering-para"><strong>Location Intelligence</strong> — Spatial context changes what data means. We develop geospatial data strategies, build location-aware
                   AI applications, and integrate spatial analysis into decision-making workflows that were previously
                   blind to geography.</p>
-<p class="essay-offering-para"><strong>Generative Engine Optimization</strong>&#160;&#8212;&#160;As AI reshapes search, your organization&#8217;s presence in AI-generated answers matters as much as its
+<p class="essay-offering-para"><strong>Generative Engine Optimization</strong> — As AI reshapes search, your organization’s presence in AI-generated answers matters as much as its
                   traditional search ranking. We make sure you appear accurately and prominently in the outputs that now
                   shape how people find information.</p>
-<p class="essay-offering-para"><strong>Executive AI Coaching</strong>&#160;&#8212;&#160;One-to-one advisory for leaders who need to understand AI well enough to make decisions about it &#8212;
+<p class="essay-offering-para"><strong>Executive AI Coaching</strong> — One-to-one advisory for leaders who need to understand AI well enough to make decisions about it —
                   without wading through hype. Strategy, governance, and an honest assessment of what your organization
                   is actually ready for and when.</p>
 </div>
@@ -1095,20 +1096,20 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <div class="essay-section-label">How We Work</div>
 <div class="essay-main"><ol class="essay-steps">
 <li>
-<strong>Audit</strong>We take full inventory of your data: what you have, where it lives, what quality it&#8217;s in, and where
+<strong>Audit</strong>We take full inventory of your data: what you have, where it lives, what quality it’s in, and where
                     the gaps are. Nothing proceeds on assumptions about the state of your data infrastructure.</li>
 <li>
 <strong>Assessment</strong>We map your AI capabilities against realistic benchmarks, identify specific risks, and score your
-                    readiness across the dimensions that matter for your context &#8212; not against a generic maturity
+                    readiness across the dimensions that matter for your context — not against a generic maturity
                     framework.</li>
 <li>
 <strong>Strategy</strong>A concrete roadmap with sequenced initiatives, a governance framework that can actually be followed
                     by real teams, and an adoption plan grounded in your organizational reality rather than best-case
                     projections.</li>
 <li>
-<strong>Handoff</strong>We don&#8217;t disappear after delivery. You receive implementation playbooks, training materials, and an
+<strong>Handoff</strong>We don’t disappear after delivery. You receive implementation playbooks, training materials, and an
                     executive alignment session to ensure the strategy lands and the people responsible for it
-                    understand what they&#8217;re holding.</li>
+                    understand what they’re holding.</li>
 </ol></div>
 <div class="sidenote">
 <span class="sidenote-heading">Steps</span><div class="sidenote-item">
@@ -1124,7 +1125,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <div class="essay-section">
 <div class="essay-section-label">Deliverables</div>
 <div class="essay-main">
-        <p>The engagement delivers a complete picture of where you stand and a clear path forward &#8212; a data audit report, an AI readiness assessment with scoring, a strategic roadmap with governance framework, and an executive presentation paired with an adoption playbook your team can actually use. For organizations that want ongoing strategic support as the landscape shifts, an advisory retainer is available.</p>
+        <p>The engagement delivers a complete picture of where you stand and a clear path forward — a data audit report, an AI readiness assessment with scoring, a strategic roadmap with governance framework, and an executive presentation paired with an adoption playbook your team can actually use. For organizations that want ongoing strategic support as the landscape shifts, an advisory retainer is available.</p>
       </div>
 <div class="sidenote">
 <span class="sidenote-heading">Included</span><div class="sidenote-item">Data audit + gap analysis</div>
@@ -1136,18 +1137,18 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </div>
 </div>
 <div class="cap-nav">
-<a href="/capabilities/003-enterprise-agents.html" class="cap-nav-prev">&#8592; Enterprise AI Agents</a><a href="/capabilities/" class="cap-nav-center">All Capabilities</a><a href="/capabilities/001-applied-research.html" class="cap-nav-next">Applied Research &#8594;</a>
+<a href="/capabilities/003-enterprise-agents.html" class="cap-nav-prev">← Enterprise AI Agents</a><a href="/capabilities/" class="cap-nav-center">All Capabilities</a><a href="/capabilities/001-applied-research.html" class="cap-nav-next">Applied Research →</a>
 </div>
 <div class="cta-block">
 <div><h3>Ready to know where you actually stand?</h3></div>
-<a href="/contact/" style="text-decoration:none;"><div class="cta-btn">Get in touch &#8594;</div></a>
+<a href="/contact/" style="text-decoration:none;"><div class="cta-btn">Get in touch →</div></a>
 </div>
 <div class="footer">
 <div>
 <span class="label" style="color: var(--color-terra);">Inquiries</span><h2><a href="mailto:innovation@ajared.ca">innovation@<span style="color: #a1665e;">aja</span>red.ca</a></h2>
 </div>
 <div style="text-align:right; display:flex; flex-direction:column; justify-content:center; align-items:flex-end; gap:0.5rem;">
-<p>&#169; 2026 Ajared Research Inc.</p>
+<p>© 2026 Ajared Research Inc.</p>
 <span class="label">R<span style="color:#a1665e">e</span>s<span style="color:#a1665e">ea</span>rch,
                 <span style="color:#a1665e">e</span>d<span style="color:#a1665e">u</span>c<span style="color:#a1665e">a</span>t<span style="color:#a1665e">e</span>, d<span style="color:#a1665e">e</span>s<span style="color:#a1665e">i</span>gn.</span>
 </div>

--- a/capabilities/index.html
+++ b/capabilities/index.html
@@ -1,6 +1,7 @@
-<!DOCTYPE html SYSTEM "about:legacy-compat">
+<!DOCTYPE html>
 <html lang="en">
 <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
@@ -12,17 +13,17 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/favicon-32x32.png">
-<title>Capabilities &#8212; Ajared Research Inc</title>
+<title>Capabilities — Ajared Research Inc</title>
 <meta name="description" content="Explore Ajared Research Inc's capabilities: applied AI research, AI product development, enterprise agents, and data strategy for modern organizations.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://ajared.ca/capabilities/">
-<meta property="og:title" content="Capabilities &#8212; Ajared Research Inc">
+<meta property="og:title" content="Capabilities — Ajared Research Inc">
 <meta property="og:description" content="Explore Ajared Research Inc's capabilities: applied AI research, AI product development, enterprise agents, and data strategy for modern organizations.">
 <meta property="og:image" content="https://ajared.ca/social-card-bw.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="628">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Capabilities &#8212; Ajared Research Inc">
+<meta name="twitter:title" content="Capabilities — Ajared Research Inc">
 <meta name="twitter:description" content="Explore Ajared Research Inc's capabilities: applied AI research, AI product development, enterprise agents, and data strategy for modern organizations.">
 <meta name="twitter:image" content="https://ajared.ca/social-card-bw.png">
 <style>
@@ -257,7 +258,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             font-size: 1rem;
         }
 
-        /* Change 11: Nav hover &#8212; terra cotta */
+        /* Change 11: Nav hover — terra cotta */
         nav a:hover {
             text-decoration: underline;
             color: var(--color-terra);
@@ -313,7 +314,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             pointer-events: none;
         }
 
-        /* Change 10: Secondary ripple rings &#8212; subtle terra cotta tint */
+        /* Change 10: Secondary ripple rings — subtle terra cotta tint */
         .ripple-secondary {
             position: absolute;
             border-radius: 50%;
@@ -373,7 +374,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             margin-bottom: 0.5rem;
         }
 
-        /* Arrow &#8212; Change 3: terra cotta by default */
+        /* Arrow — Change 3: terra cotta by default */
         .arrow-icon {
             width: 40px;
             height: 1px;
@@ -406,7 +407,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             border-right-color: var(--color-bg);
         }
 
-        /* Stretched link &#8212; entire card is clickable */
+        /* Stretched link — entire card is clickable */
         .service-card > a {
             position: static;
         }
@@ -416,7 +417,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             inset: 0;
         }
 
-        /* Button &#8212; Change 1: terra cotta border + text, fills on hover */
+        /* Button — Change 1: terra cotta border + text, fills on hover */
         .btn {
             display: inline-block;
             margin-top: 2rem;
@@ -562,7 +563,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             color: var(--color-bg);
         }
 
-        /* Offer card tracks (card 03 &#8212; Get Started with AI) */
+        /* Offer card tracks (card 03 — Get Started with AI) */
         .track-list {
             margin-top: 1rem;
             display: flex;
@@ -759,7 +760,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         .hero-detail-content { position: relative; z-index: 1; }
         .hero-detail h1 { font-family: var(--font-primary); font-size: clamp(1.8rem, 3.5vw, 3.2rem); font-weight: 700; letter-spacing: -0.045em; line-height: 0.95; color: #fff; margin-bottom: 0; }
         
-        /* &#9472;&#9472; Essay + Marginalia layout (capability detail pages) &#9472;&#9472;&#9472; */
+        /* ── Essay + Marginalia layout (capability detail pages) ─── */
         .page-body { border-bottom: var(--grid-line); }
 
         .essay-section {
@@ -914,7 +915,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         .cta-btn { font-family: var(--font-mono); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--color-terra); border: 2px solid var(--color-terra); padding: 0.9rem 1.8rem; transition: background 0.2s, color 0.2s; white-space: nowrap; background: transparent; }
         .cta-btn:hover { background: var(--color-terra); color: #fff; }
 
-        /* &#9472;&#9472; Deliverable List &#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472; */
+        /* ── Deliverable List ─────────────────────────────────── */
         .deliverable-list { border-top: var(--grid-line); }
         .deliverable-row {
             display: grid;
@@ -1114,7 +1115,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <p><a href="/case-studies/">Case Studies</a></p>
 <p><a href="/capabilities/" style="text-decoration:underline; font-weight:600; color: var(--color-terra);">Capabilities</a></p>
 <p><a href="/contact/">Contact</a></p>
-<p><a href="https://www.ajared.ng">Read</a></p></nav><div style="font-size: 2rem; line-height: 1; color: var(--color-terra);">&#8595;</div>
+<p><a href="/blog/">Blog</a></p>
+<p><a href="https://www.ajared.ng">Read</a></p></nav><div style="font-size: 2rem; line-height: 1; color: var(--color-terra);">↓</div>
 </div></header><section class="hero-fullbleed"><canvas class="moire-canvas" id="moireCanvas"></canvas><div class="hero-center-text">
 <span class="label">What We Do</span><h1>Capabilities</h1>
 </div></section><div class="stats-bar">
@@ -1144,7 +1146,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <div class="header-peek" id="peek-0">We figure out what's actually going on before anyone starts building.</div>
 <div class="capability-detail" id="detail-0"><div class="detail-inner">
 <p class="detail-brief">We figure out what's actually going on before anyone starts building. That means talking to users, studying the market, running experiments, and reviewing the existing evidence. We draw on behavioral science, statistics, and deep domain knowledge.</p>
-<div class="detail-block detail-row-link"><a href="/capabilities/001-applied-research.html" class="detail-link"><span class="link-label">Learn more</span><span class="link-arrow">&#8599;</span></a></div>
+<div class="detail-block detail-row-link"><a href="/capabilities/001-applied-research.html" class="detail-link"><span class="link-label">Learn more</span><span class="link-arrow">↗</span></a></div>
 </div></div>
 </div>
 <div class="capability-row" data-cap="002">
@@ -1154,7 +1156,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <div class="header-peek" id="peek-1">We help you build and manage AI products from concept to launch.</div>
 <div class="capability-detail" id="detail-1"><div class="detail-inner">
 <p class="detail-brief">We help you build and manage products in this AI age from concept to the first prototype through what ships and what happens after. That includes choosing the right models, designing how people interact with them, and making sure they keep working as things change.</p>
-<div class="detail-block detail-row-link"><a href="/capabilities/002-ai-product.html" class="detail-link"><span class="link-label">Learn more</span><span class="link-arrow">&#8599;</span></a></div>
+<div class="detail-block detail-row-link"><a href="/capabilities/002-ai-product.html" class="detail-link"><span class="link-label">Learn more</span><span class="link-arrow">↗</span></a></div>
 </div></div>
 </div>
 <div class="capability-row" data-cap="003">
@@ -1163,8 +1165,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </div>
 <div class="header-peek" id="peek-2">Our enterprise agents can do real work inside your company.</div>
 <div class="capability-detail" id="detail-2"><div class="detail-inner">
-<p class="detail-brief">Our enterprise agents can do real work inside your company &#8212; processing documents, coordinating between systems, handling the tasks your team shouldn't be doing manually, while running reliably, at scale.</p>
-<div class="detail-block detail-row-link"><a href="/capabilities/003-enterprise-agents.html" class="detail-link"><span class="link-label">Learn more</span><span class="link-arrow">&#8599;</span></a></div>
+<p class="detail-brief">Our enterprise agents can do real work inside your company — processing documents, coordinating between systems, handling the tasks your team shouldn't be doing manually, while running reliably, at scale.</p>
+<div class="detail-block detail-row-link"><a href="/capabilities/003-enterprise-agents.html" class="detail-link"><span class="link-label">Learn more</span><span class="link-arrow">↗</span></a></div>
 </div></div>
 </div>
 <div class="capability-row" data-cap="004">
@@ -1174,23 +1176,23 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <div class="header-peek" id="peek-3">Together we'll figure out where AI fits in your organization.</div>
 <div class="capability-detail" id="detail-3"><div class="detail-inner">
 <p class="detail-brief">Together we'll figure out where AI fits in your organization, what data you need to get there, and how to adopt it without the usual mess. Governance plans, adoption playbooks, and honest assessments of what's ready and what isn't.</p>
-<div class="detail-block detail-row-link"><a href="/capabilities/004-data-strategy.html" class="detail-link"><span class="link-label">Learn more</span><span class="link-arrow">&#8599;</span></a></div>
+<div class="detail-block detail-row-link"><a href="/capabilities/004-data-strategy.html" class="detail-link"><span class="link-label">Learn more</span><span class="link-arrow">↗</span></a></div>
 </div></div>
 </div>
 </div>
 <div class="cta-block">
 <div>
 <h3>Seen enough?<br>Let's talk.</h3>
-<p style="font-family: var(--font-mono); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--color-ink-light); margin-top: 0.75rem; line-height: 1.5; max-width: none;">30 min &#183; No pitch &#183; Just a straight conversation about where AI fits you</p>
+<p style="font-family: var(--font-mono); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--color-ink-light); margin-top: 0.75rem; line-height: 1.5; max-width: none;">30 min · No pitch · Just a straight conversation about where AI fits you</p>
 </div>
-<a href="https://cal.com/ajared/talk-to-a-human-about-ai" style="text-decoration:none;"><div class="cta-btn">Book a call &#8594;</div></a>
+<a href="https://cal.com/ajared/talk-to-a-human-about-ai" style="text-decoration:none;"><div class="cta-btn">Book a call →</div></a>
 </div>
 <div class="footer">
 <div>
 <span class="label" style="color: var(--color-terra);">Inquiries</span><h2><a href="mailto:innovation@ajared.ca">innovation@<span style="color: #a1665e;">aja</span>red.ca</a></h2>
 </div>
 <div style="text-align:right; display:flex; flex-direction:column; justify-content:center; align-items:flex-end; gap:0.5rem;">
-<p>&#169; 2026 Ajared Research Inc.</p>
+<p>© 2026 Ajared Research Inc.</p>
 <span class="label">R<span style="color:#a1665e">e</span>s<span style="color:#a1665e">ea</span>rch,
                 <span style="color:#a1665e">e</span>d<span style="color:#a1665e">u</span>c<span style="color:#a1665e">a</span>t<span style="color:#a1665e">e</span>, d<span style="color:#a1665e">e</span>s<span style="color:#a1665e">i</span>gn.</span>
 </div>

--- a/case-studies/index.html
+++ b/case-studies/index.html
@@ -1,6 +1,7 @@
-<!DOCTYPE html SYSTEM "about:legacy-compat">
+<!DOCTYPE html>
 <html lang="en">
 <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
@@ -12,17 +13,17 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/favicon-32x32.png">
-<title>Case Studies &#8212; Ajared Research Inc</title>
+<title>Case Studies — Ajared Research Inc</title>
 <meta name="description" content="Real-world AI implementations by Ajared Research Inc. See how we've helped enterprises ship AI products and automate complex workflows.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://ajared.ca/case-studies/">
-<meta property="og:title" content="Case Studies &#8212; Ajared Research Inc">
+<meta property="og:title" content="Case Studies — Ajared Research Inc">
 <meta property="og:description" content="Real-world AI implementations by Ajared Research Inc. See how we've helped enterprises ship AI products and automate complex workflows.">
 <meta property="og:image" content="https://ajared.ca/social-card-bw.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="628">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Case Studies &#8212; Ajared Research Inc">
+<meta name="twitter:title" content="Case Studies — Ajared Research Inc">
 <meta name="twitter:description" content="Real-world AI implementations by Ajared Research Inc. See how we've helped enterprises ship AI products and automate complex workflows.">
 <meta name="twitter:image" content="https://ajared.ca/social-card-bw.png">
 <style>
@@ -257,7 +258,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             font-size: 1rem;
         }
 
-        /* Change 11: Nav hover &#8212; terra cotta */
+        /* Change 11: Nav hover — terra cotta */
         nav a:hover {
             text-decoration: underline;
             color: var(--color-terra);
@@ -313,7 +314,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             pointer-events: none;
         }
 
-        /* Change 10: Secondary ripple rings &#8212; subtle terra cotta tint */
+        /* Change 10: Secondary ripple rings — subtle terra cotta tint */
         .ripple-secondary {
             position: absolute;
             border-radius: 50%;
@@ -373,7 +374,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             margin-bottom: 0.5rem;
         }
 
-        /* Arrow &#8212; Change 3: terra cotta by default */
+        /* Arrow — Change 3: terra cotta by default */
         .arrow-icon {
             width: 40px;
             height: 1px;
@@ -406,7 +407,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             border-right-color: var(--color-bg);
         }
 
-        /* Stretched link &#8212; entire card is clickable */
+        /* Stretched link — entire card is clickable */
         .service-card > a {
             position: static;
         }
@@ -416,7 +417,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             inset: 0;
         }
 
-        /* Button &#8212; Change 1: terra cotta border + text, fills on hover */
+        /* Button — Change 1: terra cotta border + text, fills on hover */
         .btn {
             display: inline-block;
             margin-top: 2rem;
@@ -562,7 +563,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             color: var(--color-bg);
         }
 
-        /* Offer card tracks (card 03 &#8212; Get Started with AI) */
+        /* Offer card tracks (card 03 — Get Started with AI) */
         .track-list {
             margin-top: 1rem;
             display: flex;
@@ -759,7 +760,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         .hero-detail-content { position: relative; z-index: 1; }
         .hero-detail h1 { font-family: var(--font-primary); font-size: clamp(1.8rem, 3.5vw, 3.2rem); font-weight: 700; letter-spacing: -0.045em; line-height: 0.95; color: #fff; margin-bottom: 0; }
         
-        /* &#9472;&#9472; Essay + Marginalia layout (capability detail pages) &#9472;&#9472;&#9472; */
+        /* ── Essay + Marginalia layout (capability detail pages) ─── */
         .page-body { border-bottom: var(--grid-line); }
 
         .essay-section {
@@ -914,7 +915,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         .cta-btn { font-family: var(--font-mono); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--color-terra); border: 2px solid var(--color-terra); padding: 0.9rem 1.8rem; transition: background 0.2s, color 0.2s; white-space: nowrap; background: transparent; }
         .cta-btn:hover { background: var(--color-terra); color: #fff; }
 
-        /* &#9472;&#9472; Deliverable List &#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472; */
+        /* ── Deliverable List ─────────────────────────────────── */
         .deliverable-list { border-top: var(--grid-line); }
         .deliverable-row {
             display: grid;
@@ -1089,12 +1090,13 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <p><a href="/case-studies/" style="text-decoration:underline; font-weight:600; color: var(--color-terra);">Case Studies</a></p>
 <p><a href="/capabilities/">Capabilities</a></p>
 <p><a href="/contact/">Contact</a></p>
-<p><a href="https://www.ajared.ng">Read</a></p></nav><div style="font-size: 2rem; line-height: 1; color: var(--color-terra);">&#8595;</div>
+<p><a href="/blog/">Blog</a></p>
+<p><a href="https://www.ajared.ng">Read</a></p></nav><div style="font-size: 2rem; line-height: 1; color: var(--color-terra);">↓</div>
 </div></header><section class="hero-section"><div class="hero-text">
 <span class="label" style="margin-bottom: 2rem; color: var(--color-terra);">Work</span><h1>Case<br>Studies</h1>
 </div>
 <div class="moire-static" style="transform: scale(1.5);"></div>
-<div class="moire-static" style="transform: scale(1.2); right: 5%;"></div></section><div class="calibration-grid"><a href="#" class="project-row"><span class="project-id">001</span><span class="project-title">DeckSense</span><span class="project-meta">AI Product Management</span><span class="project-year">2025</span><span style="text-align: right; color: var(--color-terra);">&#8599;</span></a></div>
+<div class="moire-static" style="transform: scale(1.2); right: 5%;"></div></section><div class="calibration-grid"><a href="#" class="project-row"><span class="project-id">001</span><span class="project-title">DeckSense</span><span class="project-meta">AI Product Management</span><span class="project-year">2025</span><span style="text-align: right; color: var(--color-terra);">↗</span></a></div>
 </div>
 </div>
 </body>

--- a/contact/index.html
+++ b/contact/index.html
@@ -1,6 +1,7 @@
-<!DOCTYPE html SYSTEM "about:legacy-compat">
+<!DOCTYPE html>
 <html lang="en">
 <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
@@ -12,17 +13,17 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/favicon-32x32.png">
-<title>Contact &#8212; Ajared Research Inc</title>
+<title>Contact — Ajared Research Inc</title>
 <meta name="description" content="Get in touch with Ajared Research Inc. Start a conversation about applied AI, enterprise agents, or your next AI initiative.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://ajared.ca/contact/">
-<meta property="og:title" content="Contact &#8212; Ajared Research Inc">
+<meta property="og:title" content="Contact — Ajared Research Inc">
 <meta property="og:description" content="Get in touch with Ajared Research Inc. Start a conversation about applied AI, enterprise agents, or your next AI initiative.">
 <meta property="og:image" content="https://ajared.ca/social-card-bw.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="628">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Contact &#8212; Ajared Research Inc">
+<meta name="twitter:title" content="Contact — Ajared Research Inc">
 <meta name="twitter:description" content="Get in touch with Ajared Research Inc. Start a conversation about applied AI, enterprise agents, or your next AI initiative.">
 <meta name="twitter:image" content="https://ajared.ca/social-card-bw.png">
 <style>
@@ -257,7 +258,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             font-size: 1rem;
         }
 
-        /* Change 11: Nav hover &#8212; terra cotta */
+        /* Change 11: Nav hover — terra cotta */
         nav a:hover {
             text-decoration: underline;
             color: var(--color-terra);
@@ -313,7 +314,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             pointer-events: none;
         }
 
-        /* Change 10: Secondary ripple rings &#8212; subtle terra cotta tint */
+        /* Change 10: Secondary ripple rings — subtle terra cotta tint */
         .ripple-secondary {
             position: absolute;
             border-radius: 50%;
@@ -373,7 +374,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             margin-bottom: 0.5rem;
         }
 
-        /* Arrow &#8212; Change 3: terra cotta by default */
+        /* Arrow — Change 3: terra cotta by default */
         .arrow-icon {
             width: 40px;
             height: 1px;
@@ -406,7 +407,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             border-right-color: var(--color-bg);
         }
 
-        /* Stretched link &#8212; entire card is clickable */
+        /* Stretched link — entire card is clickable */
         .service-card > a {
             position: static;
         }
@@ -416,7 +417,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             inset: 0;
         }
 
-        /* Button &#8212; Change 1: terra cotta border + text, fills on hover */
+        /* Button — Change 1: terra cotta border + text, fills on hover */
         .btn {
             display: inline-block;
             margin-top: 2rem;
@@ -562,7 +563,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             color: var(--color-bg);
         }
 
-        /* Offer card tracks (card 03 &#8212; Get Started with AI) */
+        /* Offer card tracks (card 03 — Get Started with AI) */
         .track-list {
             margin-top: 1rem;
             display: flex;
@@ -759,7 +760,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         .hero-detail-content { position: relative; z-index: 1; }
         .hero-detail h1 { font-family: var(--font-primary); font-size: clamp(1.8rem, 3.5vw, 3.2rem); font-weight: 700; letter-spacing: -0.045em; line-height: 0.95; color: #fff; margin-bottom: 0; }
         
-        /* &#9472;&#9472; Essay + Marginalia layout (capability detail pages) &#9472;&#9472;&#9472; */
+        /* ── Essay + Marginalia layout (capability detail pages) ─── */
         .page-body { border-bottom: var(--grid-line); }
 
         .essay-section {
@@ -914,7 +915,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         .cta-btn { font-family: var(--font-mono); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--color-terra); border: 2px solid var(--color-terra); padding: 0.9rem 1.8rem; transition: background 0.2s, color 0.2s; white-space: nowrap; background: transparent; }
         .cta-btn:hover { background: var(--color-terra); color: #fff; }
 
-        /* &#9472;&#9472; Deliverable List &#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472; */
+        /* ── Deliverable List ─────────────────────────────────── */
         .deliverable-list { border-top: var(--grid-line); }
         .deliverable-row {
             display: grid;
@@ -1073,11 +1074,12 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <p><a href="/case-studies/">Case Studies</a></p>
 <p><a href="/capabilities/">Capabilities</a></p>
 <p><a href="/contact/" style="text-decoration:underline; font-weight:600; color: var(--color-terra);">Contact</a></p>
-<p><a href="https://www.ajared.ng">Read</a></p></nav><div style="font-size: 2rem; line-height: 1; color: var(--color-terra);">&#8599;</div>
+<p><a href="/blog/">Blog</a></p>
+<p><a href="https://www.ajared.ng">Read</a></p></nav><div style="font-size: 2rem; line-height: 1; color: var(--color-terra);">↗</div>
 </div></header><section class="form-section"><div class="form-left">
 <span class="label">Contact</span><h1>New Inquiry</h1>
 <form id="commission-form" action="https://formspree.io/f/mrearkjn" method="POST">
-<input type="hidden" name="_subject" value="New Inquiry &#8212; Ajared Research Inc"><input type="hidden" name="_replyto" value=""><div class="instrument-field">
+<input type="hidden" name="_subject" value="New Inquiry — Ajared Research Inc"><input type="hidden" name="_replyto" value=""><div class="instrument-field">
 <span class="label">01 / Principal Contact</span><input type="text" name="name" required="required" class="instrument-input" placeholder="Organization or Individual">
 </div>
 <div class="instrument-field">
@@ -1090,11 +1092,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <span class="label" id="scope-label">03 / Project Scope / Brief</span><textarea name="message" id="message-textarea" class="brief-textarea" placeholder="Tell us what you're working on and we'll let you know how we can help..."></textarea>
 </div>
 <div id="form-status" style="display:none; margin-top:1rem; font-family:var(--font-mono); font-size:0.85rem; letter-spacing:0.05em; text-transform:uppercase;"></div>
-<button type="submit" class="btn-submit" id="submit-btn">Send Message &#8599;</button>
+<button type="submit" class="btn-submit" id="submit-btn">Send Message ↗</button>
 </form>
 </div>
 <div class="form-right"><div style="margin-top: 4rem;">
-<span class="label">Response Times</span><p>We typically respond within 48&#8211;72 hours.</p>
+<span class="label">Response Times</span><p>We typically respond within 48–72 hours.</p>
 </div></div></section>
 </div>
 </div>

--- a/deliverables/index.html
+++ b/deliverables/index.html
@@ -1,6 +1,7 @@
-<!DOCTYPE html SYSTEM "about:legacy-compat">
+<!DOCTYPE html>
 <html lang="en">
 <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
@@ -12,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/favicon-32x32.png">
-<title>Your AI Starter Kit &#8212; Ajared Research Inc</title>
+<title>Your AI Starter Kit — Ajared Research Inc</title>
 <style>
         /* iA Writer Quattro S Font */
         @font-face {
@@ -245,7 +246,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             font-size: 1rem;
         }
 
-        /* Change 11: Nav hover &#8212; terra cotta */
+        /* Change 11: Nav hover — terra cotta */
         nav a:hover {
             text-decoration: underline;
             color: var(--color-terra);
@@ -301,7 +302,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             pointer-events: none;
         }
 
-        /* Change 10: Secondary ripple rings &#8212; subtle terra cotta tint */
+        /* Change 10: Secondary ripple rings — subtle terra cotta tint */
         .ripple-secondary {
             position: absolute;
             border-radius: 50%;
@@ -361,7 +362,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             margin-bottom: 0.5rem;
         }
 
-        /* Arrow &#8212; Change 3: terra cotta by default */
+        /* Arrow — Change 3: terra cotta by default */
         .arrow-icon {
             width: 40px;
             height: 1px;
@@ -394,7 +395,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             border-right-color: var(--color-bg);
         }
 
-        /* Stretched link &#8212; entire card is clickable */
+        /* Stretched link — entire card is clickable */
         .service-card > a {
             position: static;
         }
@@ -404,7 +405,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             inset: 0;
         }
 
-        /* Button &#8212; Change 1: terra cotta border + text, fills on hover */
+        /* Button — Change 1: terra cotta border + text, fills on hover */
         .btn {
             display: inline-block;
             margin-top: 2rem;
@@ -550,7 +551,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             color: var(--color-bg);
         }
 
-        /* Offer card tracks (card 03 &#8212; Get Started with AI) */
+        /* Offer card tracks (card 03 — Get Started with AI) */
         .track-list {
             margin-top: 1rem;
             display: flex;
@@ -747,7 +748,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         .hero-detail-content { position: relative; z-index: 1; }
         .hero-detail h1 { font-family: var(--font-primary); font-size: clamp(1.8rem, 3.5vw, 3.2rem); font-weight: 700; letter-spacing: -0.045em; line-height: 0.95; color: #fff; margin-bottom: 0; }
         
-        /* &#9472;&#9472; Essay + Marginalia layout (capability detail pages) &#9472;&#9472;&#9472; */
+        /* ── Essay + Marginalia layout (capability detail pages) ─── */
         .page-body { border-bottom: var(--grid-line); }
 
         .essay-section {
@@ -902,7 +903,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         .cta-btn { font-family: var(--font-mono); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--color-terra); border: 2px solid var(--color-terra); padding: 0.9rem 1.8rem; transition: background 0.2s, color 0.2s; white-space: nowrap; background: transparent; }
         .cta-btn:hover { background: var(--color-terra); color: #fff; }
 
-        /* &#9472;&#9472; Deliverable List &#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472; */
+        /* ── Deliverable List ─────────────────────────────────── */
         .deliverable-list { border-top: var(--grid-line); }
         .deliverable-row {
             display: grid;
@@ -1004,9 +1005,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <p><a href="/case-studies/">Case Studies</a></p>
 <p><a href="/capabilities/">Capabilities</a></p>
 <p><a href="/contact/">Contact</a></p>
-<p><a href="https://www.ajared.ng">Read</a></p></nav><div style="font-size: 2rem; line-height: 1; color: var(--color-terra);">&#8599;</div>
+<p><a href="/blog/">Blog</a></p>
+<p><a href="https://www.ajared.ng">Read</a></p></nav><div style="font-size: 2rem; line-height: 1; color: var(--color-terra);">↗</div>
 </div></header><section class="hero-fullbleed"><canvas class="moire-canvas" id="moireCanvas"></canvas><div class="hero-center-text">
-<span class="label">Talk to a Human about AI &#8212; Resources</span><h1>Your AI<br>Starter Kit</h1>
+<span class="label">Talk to a Human about AI — Resources</span><h1>Your AI<br>Starter Kit</h1>
 </div></section><div class="stats-bar">
 <div class="stat-cell">
 <div class="stat-number">5</div>
@@ -1028,35 +1030,35 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <div class="ruler-x" style="position:relative; z-index:1;"></div>
 <div class="deliverable-list">
 <a href="/deliverables/01_AI_Opportunity_Audit_Worksheet.html" class="deliverable-row" target="_blank"><span class="deliverable-num">01</span><div class="deliverable-body">
-<span class="deliverable-tag">Pre-Call &#183; Fillable Form</span><span class="deliverable-title">AI Opportunity Audit Worksheet</span><p class="deliverable-desc">Fill in before your call. Covers your role, AI tools you use, top time drains, and what you want to walk away with. Takes 5 minutes &#8212; makes the call twice as useful.</p>
+<span class="deliverable-tag">Pre-Call · Fillable Form</span><span class="deliverable-title">AI Opportunity Audit Worksheet</span><p class="deliverable-desc">Fill in before your call. Covers your role, AI tools you use, top time drains, and what you want to walk away with. Takes 5 minutes — makes the call twice as useful.</p>
 </div>
 <div class="deliverable-arrow"></div></a><a href="/deliverables/02_Whats_Actually_Working_AI_Briefing.html" class="deliverable-row" target="_blank"><span class="deliverable-num">02</span><div class="deliverable-body">
-<span class="deliverable-tag">Reference &#183; Read</span><span class="deliverable-title">What's Actually Working in AI</span><p class="deliverable-desc">An opinionated briefing on the current AI landscape. The models worth knowing, the tools earning their keep, and what to skip &#8212; updated for 2026.</p>
+<span class="deliverable-tag">Reference · Read</span><span class="deliverable-title">What's Actually Working in AI</span><p class="deliverable-desc">An opinionated briefing on the current AI landscape. The models worth knowing, the tools earning their keep, and what to skip — updated for 2026.</p>
 </div>
 <div class="deliverable-arrow"></div></a><a href="/deliverables/03_AI_Prompt_Starter_Kit.html" class="deliverable-row" target="_blank"><span class="deliverable-num">03</span><div class="deliverable-body">
-<span class="deliverable-tag">Tool &#183; Interactive</span><span class="deliverable-title">AI Prompt Starter Kit</span><p class="deliverable-desc">25 practitioner-grade prompts across 5 roles: Executive, Product, Operations, Writing, and AI-Native workflows. Searchable, filterable, one-click copy.</p>
+<span class="deliverable-tag">Tool · Interactive</span><span class="deliverable-title">AI Prompt Starter Kit</span><p class="deliverable-desc">25 practitioner-grade prompts across 5 roles: Executive, Product, Operations, Writing, and AI-Native workflows. Searchable, filterable, one-click copy.</p>
 </div>
 <div class="deliverable-arrow"></div></a><a href="/deliverables/04_AI_Landscape_Mindmap.html" class="deliverable-row" target="_blank"><span class="deliverable-num">04</span><div class="deliverable-body">
-<span class="deliverable-tag">Tool &#183; Interactive</span><span class="deliverable-title">AI Landscape Mindmap</span><p class="deliverable-desc">A visual map of the full AI landscape &#8212; models, use cases, tools, agentic systems, infrastructure, and adoption strategy. Use it to locate where you are today.</p>
+<span class="deliverable-tag">Tool · Interactive</span><span class="deliverable-title">AI Landscape Mindmap</span><p class="deliverable-desc">A visual map of the full AI landscape — models, use cases, tools, agentic systems, infrastructure, and adoption strategy. Use it to locate where you are today.</p>
 </div>
 <div class="deliverable-arrow"></div></a><a href="/deliverables/05_Post_Call_Action_Plan.html" class="deliverable-row" target="_blank"><span class="deliverable-num">05</span><div class="deliverable-body">
-<span class="deliverable-tag">Post-Call &#183; Fillable Form</span><span class="deliverable-title">Post-Call Action Plan</span><p class="deliverable-desc">Sent to you within 24 hours of your call. Your top 3 AI opportunities, a prioritised first step, what to avoid, and follow-up from Chu. Download as PDF.</p>
+<span class="deliverable-tag">Post-Call · Fillable Form</span><span class="deliverable-title">Post-Call Action Plan</span><p class="deliverable-desc">Sent to you within 24 hours of your call. Your top 3 AI opportunities, a prioritised first step, what to avoid, and follow-up from Chu. Download as PDF.</p>
 </div>
 <div class="deliverable-arrow"></div></a>
 </div>
 <div class="cta-block">
 <div>
 <h3>Ready to book<br>your call?</h3>
-<p style="font-family: var(--font-mono); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--color-ink-light); margin-top: 0.75rem; line-height: 1.5; max-width: none;">30 min &#183; No pitch &#183; Just a straight conversation about where AI fits you</p>
+<p style="font-family: var(--font-mono); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--color-ink-light); margin-top: 0.75rem; line-height: 1.5; max-width: none;">30 min · No pitch · Just a straight conversation about where AI fits you</p>
 </div>
-<a href="https://cal.com/ajared/talk-to-a-human-about-ai" style="text-decoration:none;"><div class="cta-btn">Book a call &#8594;</div></a>
+<a href="https://cal.com/ajared/talk-to-a-human-about-ai" style="text-decoration:none;"><div class="cta-btn">Book a call →</div></a>
 </div>
 <div class="footer">
 <div>
 <span class="label" style="color: var(--color-terra);">Inquiries</span><h2><a href="mailto:innovation@ajared.ca">innovation@<span style="color: #a1665e;">aja</span>red.ca</a></h2>
 </div>
 <div style="text-align:right; display:flex; flex-direction:column; justify-content:center; align-items:flex-end; gap:0.5rem;">
-<p>&#169; 2026 Ajared Research Inc.</p>
+<p>© 2026 Ajared Research Inc.</p>
 <span class="label">R<span style="color:#a1665e">e</span>s<span style="color:#a1665e">ea</span>rch,
                 <span style="color:#a1665e">e</span>d<span style="color:#a1665e">u</span>c<span style="color:#a1665e">a</span>t<span style="color:#a1665e">e</span>, d<span style="color:#a1665e">e</span>s<span style="color:#a1665e">i</span>gn.</span>
 </div>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
-<!DOCTYPE html SYSTEM "about:legacy-compat">
+<!DOCTYPE html>
 <html lang="en">
 <head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
@@ -12,18 +13,18 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/favicon-32x32.png">
-<title>Applied AI for Enterprises &#8212; Ajared Research Inc</title>
-<meta name="description" content="Ajared Research Inc helps enterprises implement AI that works &#8212; applied research, product development, and intelligent agents built for real operations.">
+<title>Applied AI for Enterprises — Ajared Research Inc</title>
+<meta name="description" content="Ajared Research Inc helps enterprises implement AI that works — applied research, product development, and intelligent agents built for real operations.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://ajared.ca/">
-<meta property="og:title" content="Applied AI for Enterprises &#8212; Ajared Research Inc">
-<meta property="og:description" content="Ajared Research Inc helps enterprises implement AI that works &#8212; applied research, product development, and intelligent agents built for real operations.">
+<meta property="og:title" content="Applied AI for Enterprises — Ajared Research Inc">
+<meta property="og:description" content="Ajared Research Inc helps enterprises implement AI that works — applied research, product development, and intelligent agents built for real operations.">
 <meta property="og:image" content="https://ajared.ca/social-card-bw.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="628">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Applied AI for Enterprises &#8212; Ajared Research Inc">
-<meta name="twitter:description" content="Ajared Research Inc helps enterprises implement AI that works &#8212; applied research, product development, and intelligent agents built for real operations.">
+<meta name="twitter:title" content="Applied AI for Enterprises — Ajared Research Inc">
+<meta name="twitter:description" content="Ajared Research Inc helps enterprises implement AI that works — applied research, product development, and intelligent agents built for real operations.">
 <meta name="twitter:image" content="https://ajared.ca/social-card-bw.png">
 <style>
         /* iA Writer Quattro S Font */
@@ -257,7 +258,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             font-size: 1rem;
         }
 
-        /* Change 11: Nav hover &#8212; terra cotta */
+        /* Change 11: Nav hover — terra cotta */
         nav a:hover {
             text-decoration: underline;
             color: var(--color-terra);
@@ -313,7 +314,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             pointer-events: none;
         }
 
-        /* Change 10: Secondary ripple rings &#8212; subtle terra cotta tint */
+        /* Change 10: Secondary ripple rings — subtle terra cotta tint */
         .ripple-secondary {
             position: absolute;
             border-radius: 50%;
@@ -373,7 +374,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             margin-bottom: 0.5rem;
         }
 
-        /* Arrow &#8212; Change 3: terra cotta by default */
+        /* Arrow — Change 3: terra cotta by default */
         .arrow-icon {
             width: 40px;
             height: 1px;
@@ -406,7 +407,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             border-right-color: var(--color-bg);
         }
 
-        /* Stretched link &#8212; entire card is clickable */
+        /* Stretched link — entire card is clickable */
         .service-card > a {
             position: static;
         }
@@ -416,7 +417,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             inset: 0;
         }
 
-        /* Button &#8212; Change 1: terra cotta border + text, fills on hover */
+        /* Button — Change 1: terra cotta border + text, fills on hover */
         .btn {
             display: inline-block;
             margin-top: 2rem;
@@ -562,7 +563,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             color: var(--color-bg);
         }
 
-        /* Offer card tracks (card 03 &#8212; Get Started with AI) */
+        /* Offer card tracks (card 03 — Get Started with AI) */
         .track-list {
             margin-top: 1rem;
             display: flex;
@@ -759,7 +760,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         .hero-detail-content { position: relative; z-index: 1; }
         .hero-detail h1 { font-family: var(--font-primary); font-size: clamp(1.8rem, 3.5vw, 3.2rem); font-weight: 700; letter-spacing: -0.045em; line-height: 0.95; color: #fff; margin-bottom: 0; }
         
-        /* &#9472;&#9472; Essay + Marginalia layout (capability detail pages) &#9472;&#9472;&#9472; */
+        /* ── Essay + Marginalia layout (capability detail pages) ─── */
         .page-body { border-bottom: var(--grid-line); }
 
         .essay-section {
@@ -914,7 +915,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         .cta-btn { font-family: var(--font-mono); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--color-terra); border: 2px solid var(--color-terra); padding: 0.9rem 1.8rem; transition: background 0.2s, color 0.2s; white-space: nowrap; background: transparent; }
         .cta-btn:hover { background: var(--color-terra); color: #fff; }
 
-        /* &#9472;&#9472; Deliverable List &#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472; */
+        /* ── Deliverable List ─────────────────────────────────── */
         .deliverable-list { border-top: var(--grid-line); }
         .deliverable-row {
             display: grid;
@@ -1142,7 +1143,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <span class="label" style="color: var(--color-ink);">Information Architecture</span><a href="/" style="text-decoration: none; display: block;"><img src="/logo.png" alt="Ajared Logo" style="height: 60px; width: auto; display: block; margin-bottom: 0.4rem;"><div class="logo-text" style="font-size: 1.6rem; font-weight: 700; letter-spacing: -0.02em; line-height: 1.1;">Research Inc.</div></a>
 </div>
 <div class="header-cell">
-<span class="label">Coordinates</span><p style="font-size: 0.85em;">Toronto<br><span style="color: var(--color-terra);">43.6332&#176; N, 79.4141&#176; W</span><br>Abuja<br><span style="color: var(--color-terra);">8.9976&#176; N, 7.4674&#176; E</span></p>
+<span class="label">Coordinates</span><p style="font-size: 0.85em;">Toronto<br><span style="color: var(--color-terra);">43.6332° N, 79.4141° W</span><br>Abuja<br><span style="color: var(--color-terra);">8.9976° N, 7.4674° E</span></p>
 <div>
 <span class="label">Status</span><p style="font-size: 0.85em;"><span style="display:inline-block; width:7px; height:7px; border-radius:50%; background:var(--color-terra); margin-right:7px; vertical-align:middle; position:relative; top:-1px;"></span><span style="color: var(--color-terra);">Open for Collaboration</span></p>
 </div>
@@ -1152,19 +1153,20 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <p><a href="/case-studies/">Case Studies</a></p>
 <p><a href="/capabilities/">Capabilities</a></p>
 <p><a href="/contact/">Contact</a></p>
-<p><a href="https://www.ajared.ng">Read</a></p></nav><div style="font-size: 2rem; line-height: 1; color: var(--color-terra);">&#8599;</div>
+<p><a href="/blog/">Blog</a></p>
+<p><a href="https://www.ajared.ng">Read</a></p></nav><div style="font-size: 2rem; line-height: 1; color: var(--color-terra);">↗</div>
 </div></header><section class="hero-section"><div class="hero-text">
 <span class="label" style="margin-bottom: 2rem; color: #a1665e;">AI Research &amp; Product Studio</span><h1>Get AI<br>working<br>for you<br><span style="color:#a1665e;">today.</span>
 </h1>
-<p style="margin-top: 2rem; max-width: none;">We go past proofs of concepts to AI products that actually work for you. When you start <em>really</em> using AI today, you can supercharge your productivity &#8212; first personally, and then for your organization.</p>
-<a href="/ai-readiness/" class="btn btn-stacked"><span class="btn-label">Assess your AI readiness &#8594;</span><span class="btn-hint">Free &#183; 3 minutes &#183; Personalized action plan</span></a>
+<p style="margin-top: 2rem; max-width: none;">We go past proofs of concepts to AI products that actually work for you. When you start <em>really</em> using AI today, you can supercharge your productivity — first personally, and then for your organization.</p>
+<a href="/ai-readiness/" class="btn btn-stacked"><span class="btn-label">Assess your AI readiness →</span><span class="btn-hint">Free · 3 minutes · Personalized action plan</span></a>
 </div>
 <div class="moire-container" id="moire"></div></section><div class="ruler-x" style="position: relative; z-index: 1;"></div>
 <div class="services-grid">
 <div class="service-card">
 <div>
-<span class="label"><span style="color: #a1665e;">01</span> &#8212; Advisory</span><h3>Talk to a Human about AI</h3>
-<p>Not a chatbot or a vendor pitch. A 30-minute conversation with an AI practitioner &#8212; walk away knowing exactly where AI fits you or your organisation: what to skip, and what's actually working right now.</p>
+<span class="label"><span style="color: #a1665e;">01</span> — Advisory</span><h3>Talk to a Human about AI</h3>
+<p>Not a chatbot or a vendor pitch. A 30-minute conversation with an AI practitioner — walk away knowing exactly where AI fits you or your organisation: what to skip, and what's actually working right now.</p>
 <div class="byline">
 <div class="byline-avatar"><img src="https://chunnodu.com/images/headshot2026.jpg" alt="Chu Nnodu"></div>
 <div class="byline-text">
@@ -1176,14 +1178,14 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </div>
 <div class="service-card">
 <div>
-<span class="label"><span style="color: #a1665e;">02</span> &#8212; Build</span><h3>1 Month AI Development Sprint</h3>
+<span class="label"><span style="color: #a1665e;">02</span> — Build</span><h3>1 Month AI Development Sprint</h3>
 <p>A focused, time-boxed build. We scope it, ship it, and hand it over in four weeks. Right-sized for teams that want momentum, not a six-month SOW.</p>
 </div>
 <a href="/ai-sprint/" style="text-decoration: none; color: inherit; display: block; margin-top: 2rem;"><div class="arrow-icon"></div></a>
 </div>
 <div class="service-card">
 <div>
-<span class="label"><span style="color: #a1665e;">03</span> &#8212; Learn</span><h3>Get Started with AI</h3>
+<span class="label"><span style="color: #a1665e;">03</span> — Learn</span><h3>Get Started with AI</h3>
 <p>Three entry points depending on where you are today.</p>
 <div class="track-list">
 <div class="track-item">
@@ -1201,8 +1203,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </div>
 <div class="service-card">
 <div>
-<span class="label"><span style="color: #a1665e;">04</span> &#8212; AI Search</span><h3>Help AI Agents easily find your brand</h3>
-<p>AI agents are how people will discover you next. We add the structured data and schema markup that makes your site legible to them &#8212; today.</p>
+<span class="label"><span style="color: #a1665e;">04</span> — AI Search</span><h3>Help AI Agents easily find your brand</h3>
+<p>AI agents are how people will discover you next. We add the structured data and schema markup that makes your site legible to them — today.</p>
 </div>
 <a href="/contact/" style="text-decoration: none; color: inherit; display: block; margin-top: 2rem;"><div class="arrow-icon"></div></a>
 </div>
@@ -1212,7 +1214,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <span class="label" style="color: var(--color-terra);">Inquiries</span><h2><a href="mailto:innovation@ajared.ca">innovation@<span style="color: #a1665e;">aja</span>red.ca</a></h2>
 </div>
 <div style="text-align:right; display:flex; flex-direction:column; justify-content:center; align-items:flex-end; gap:0.5rem;">
-<p>&#169; 2026 Ajared Research Inc.</p>
+<p>© 2026 Ajared Research Inc.</p>
 <span class="label">R<span style="color:#a1665e">e</span>s<span style="color:#a1665e">ea</span>rch,
                 <span style="color:#a1665e">e</span>d<span style="color:#a1665e">u</span>c<span style="color:#a1665e">a</span>t<span style="color:#a1665e">e</span>, d<span style="color:#a1665e">e</span>s<span style="color:#a1665e">i</span>gn.</span>
 </div>

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -50,4 +50,26 @@ for xml_path in glob.glob(f"{site_root}/**/*.xml", recursive=True):
 PYEOF
 fi
 
+echo "Building blog with voxx..."
+(
+  cd "$SITE_ROOT/blog"
+  if ! command -v voxx &>/dev/null; then
+    npx --yes @prudentbird/voxx build --out ..
+  else
+    voxx build --out ..
+  fi
+)
+cat "$SITE_ROOT/blog/ajared-theme.css" >> "$SITE_ROOT/_voxx/voxx.css"
+echo "  Applied Ajared theme to _voxx/voxx.css"
+
+find "$SITE_ROOT/blog" -name "*.html" | while read -r f; do
+  sed -i '' \
+    's|>Ajared Research</a>|><img src="/logo.png" alt="Ajared Research" style="height:28px;width:auto;display:block;"/></a>|g' \
+    "$f"
+done
+sed -i '' \
+  's|<h1>\(Ajared Research\)</h1>|<h1><a href="/" style="text-decoration:none;">\1</a></h1>|g' \
+  "$SITE_ROOT/blog/index.html"
+echo "  Patched blog wordmark and index title"
+
 echo "Build complete."

--- a/site-renderer.xslt
+++ b/site-renderer.xslt
@@ -1112,6 +1112,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                 <a href="/case-studies/" style="font-size: 0.72rem;">Case Studies</a>
                 <a href="/capabilities/" style="font-size: 0.72rem;">Capabilities</a>
                 <a href="/contact/" style="font-size: 0.72rem;">Contact</a>
+                <a href="/blog/" style="font-size: 0.72rem;">Blog</a>
                 <a href="https://www.ajared.ng" style="font-size: 0.72rem;">Read</a>
               </nav>
             </div>
@@ -1187,6 +1188,16 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                           </xsl:when>
                           <xsl:otherwise>
                             <a href="/contact/">Contact</a>
+                          </xsl:otherwise>
+                        </xsl:choose>
+                    </p>
+                    <p>
+                        <xsl:choose>
+                          <xsl:when test="Nav/@active='blog'">
+                            <a href="/blog/" style="text-decoration:underline; font-weight:600; color: var(--color-terra);">Blog</a>
+                          </xsl:when>
+                          <xsl:otherwise>
+                            <a href="/blog/">Blog</a>
                           </xsl:otherwise>
                         </xsl:choose>
                     </p>


### PR DESCRIPTION
## Summary

- Adds `/blog/` route built with the Voxx blog engine
- Wires the Voxx build into `scripts/build.sh` so it runs automatically on every `git commit` (pre-commit hook)
- Adds a Blog nav link across desktop and mobile navigation with active-state styling
- Patches blog HTML output: logo image replaces text wordmark, index `<h1>` wraps home link

## What's included

| File | Purpose |
|------|---------|
| `blog/voxx.json` | Voxx config — site metadata, content dir, shadcn preset |
| `blog/content/hello-world.md` | Starter post (replace or delete) |
| `blog/ajared-theme.css` | Ajared brand overrides appended to voxx.css at build time |
| `_voxx/voxx.css` | Compiled Voxx stylesheet (committed output, do not hand-edit) |
| `_voxx/voxx-globals.css` | Voxx CSS custom property globals |
| `.gitignore` | Excludes `node_modules/` and `blog/node_modules/` |

## Note on `&#8212;` → `—`

The HTML pages show em dashes changing from the entity `&#8212;` to the literal UTF-8 character `—`. This is a serialisation difference from the updated XSLT output method — both are identical to browsers. No content changed.

## Test plan

- [ ] Visit `/blog/` — index lists posts
- [ ] Visit `/blog/hello-world/` — post renders correctly
- [ ] Check Blog link appears in desktop and mobile nav
- [ ] Run `scripts/build.sh` locally and confirm blog rebuilds cleanly